### PR TITLE
Add default execution role config item per account

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/cloudwatchlogs/cloudwatchlogs_test.go
@@ -1,0 +1,16 @@
+package cloudwatchlogs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/YaleSpinup/ecs-api/common"
+)
+
+func TestNewSession(t *testing.T) {
+	cw := NewSession(common.Account{})
+	to := reflect.TypeOf(cw).String()
+	if to != "cloudwatchlogs.CloudWatchLogs" {
+		t.Errorf("expected type to be 'cloudwatchlogs.CloudWatchLogs', got %s", to)
+	}
+}

--- a/common/config.go
+++ b/common/config.go
@@ -18,11 +18,12 @@ type Config struct {
 
 // Account is the configuration for an individual account
 type Account struct {
-	Region         string
-	Akid           string
-	Secret         string
-	DefaultSgs     []string
-	DefaultSubnets []string
+	Region                  string
+	Akid                    string
+	Secret                  string
+	DefaultSgs              []string
+	DefaultSubnets          []string
+	DefaultExecutionRoleArn string
 }
 
 // ReadConfig decodes the configuration from an io Reader

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -13,7 +13,10 @@ var testConfig = []byte(
 		  "provider1": {
 			"region": "us-east-1",
 			"akid": "key1",
-			"secret": "secret1"
+			"secret": "secret1",
+			"defaultSgs": ["sg-xxxxxx", "sg-yyyyyy"],
+			"defaultSubnets": ["subnet-xxxxxxx", "subnet-yyyyyy"],
+			"defaultExecutionRoleArn": "arn:aws:iam::1111111111111:role/ecsTaskExecutionRole"
 		  },
 		  "provider2": {
 			"region": "us-west-1",
@@ -30,9 +33,12 @@ func TestReadConfig(t *testing.T) {
 		ListenAddress: ":8000",
 		Accounts: map[string]Account{
 			"provider1": Account{
-				Region: "us-east-1",
-				Akid:   "key1",
-				Secret: "secret1",
+				Region:                  "us-east-1",
+				Akid:                    "key1",
+				Secret:                  "secret1",
+				DefaultSgs:              []string{"sg-xxxxxx", "sg-yyyyyy"},
+				DefaultSubnets:          []string{"subnet-xxxxxxx", "subnet-yyyyyy"},
+				DefaultExecutionRoleArn: "arn:aws:iam::1111111111111:role/ecsTaskExecutionRole",
 			},
 			"provider2": Account{
 				Region: "us-west-1",
@@ -50,6 +56,6 @@ func TestReadConfig(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(actualConfig, expectedConfig) {
-		t.Errorf("Expected config to be %+v, got %+v", expectedConfig, actualConfig)
+		t.Errorf("Expected config to be %+v\n got %+v", expectedConfig, actualConfig)
 	}
 }

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -6,14 +6,16 @@
       "akid": "xxxxxxxx",
       "secret": "xxxxxxxx",
       "default_sgs": ["sg-xxxxxx", "sg-yyyyyy"],
-      "default_subnets": ["subnet-xxxxxxx", "subnet-yyyyyy"]
+      "default_subnets": ["subnet-xxxxxxx", "subnet-yyyyyy"],
+      "defaultExecutionRoleArn": "arn:aws:iam::1111111111111:role/ecsTaskExecutionRole"
     },
     "spinup": {
       "region": "us-east-1",
       "akid": "xxxxxxxx",
       "secret": "xxxxxxxx",
       "default_sgs": ["sg-zzzzzz"],
-      "default_subnets": ["subnet-zzzzzz"]
+      "default_subnets": ["subnet-zzzzzz"],
+      "defaultExecutionRoleArn": "arn:aws:iam::22222222222222:role/ecsTaskExecutionRole"
     }
   },
   "token": "xxxx",

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -6,7 +6,8 @@
       "akid": "{{ .spinup_akid }}",
       "secret": "{{ .spinup_secret }}",
       "defaultSgs": ["{{ .default_sg }}"],
-      "defaultSubnets": ["{{ .default_subnet }}"]
+      "defaultSubnets": ["{{ .default_subnet }}"],
+      "defaultExecutionRoleArn": "{{ .default_exection_role_arn }}"
     }
   },
   "token": "{{ .api_token }}",

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -11,9 +11,10 @@ import (
 
 // ECS is a wrapper around the aws ECS service with some default config info
 type ECS struct {
-	Service        *ecs.ECS
-	DefaultSgs     []string
-	DefaultSubnets []string
+	Service                 *ecs.ECS
+	DefaultSgs              []string
+	DefaultSubnets          []string
+	DefaultExecutionRoleArn string
 }
 
 // NewSession creates a new ECS session
@@ -28,6 +29,7 @@ func NewSession(account common.Account) ECS {
 
 	e.DefaultSgs = account.DefaultSgs
 	e.DefaultSubnets = account.DefaultSubnets
+	e.DefaultExecutionRoleArn = account.DefaultExecutionRoleArn
 
 	return e
 }

--- a/handlers_orchestration.go
+++ b/handlers_orchestration.go
@@ -58,6 +58,10 @@ func ServiceOrchestrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 		orchestration.DefaultSubnets = sus
 	}
 
+	if AppConfig.Accounts[account].DefaultExecutionRoleArn != "" {
+		orchestration.DefaultExecutionRoleArn = aws.String(AppConfig.Accounts[account].DefaultExecutionRoleArn)
+	}
+
 	body, _ := ioutil.ReadAll(r.Body)
 	log.Debugf("new service orchestration request body: %s", body)
 

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -38,6 +38,8 @@ var (
 	DefaultSubnets = []*string{}
 	// DefaultSecurityGroups sets a list of default sgs to attach to ENIs
 	DefaultSecurityGroups = []*string{}
+	//DefaultExecutionRoleArn sets the default execution role to give the task definition
+	DefaultExecutionRoleArn = aws.String("")
 )
 
 // Orchestrator holds the service discovery client, ecs client, input, and output
@@ -316,6 +318,10 @@ func createTaskDefinition(ctx context.Context, client ecsiface.ECSAPI, input *ec
 
 	if input.NetworkMode == nil {
 		input.NetworkMode = DefaultNetworkMode
+	}
+
+	if input.ExecutionRoleArn == nil {
+		input.ExecutionRoleArn = DefaultExecutionRoleArn
 	}
 
 	output, err := client.RegisterTaskDefinitionWithContext(ctx, input)

--- a/orchestration/orchestration_test.go
+++ b/orchestration/orchestration_test.go
@@ -99,7 +99,7 @@ func (m *mockECSClient) DescribeClustersWithContext(ctx aws.Context, input *ecs.
 
 func TestCreateCluster(t *testing.T) {
 	client := &mockECSClient{}
-	cluster, err := createCluster(context.TODO(), client, aws.String("goodclu"))
+	cluster, err := createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("goodclu")})
 	if err != nil {
 		t.Fatal("expected no error from create cluster, got", err)
 	}
@@ -108,7 +108,7 @@ func TestCreateCluster(t *testing.T) {
 		t.Fatalf("Expected %+v\nGot %+v", goodClu, cluster)
 	}
 
-	cluster, err = createCluster(context.TODO(), client, aws.String("badclu"))
+	cluster, err = createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("badclu")})
 	if err == nil {
 		t.Fatal("expected error from create cluster, got", err, cluster)
 	}
@@ -126,7 +126,7 @@ func TestGetCluster(t *testing.T) {
 		t.Fatalf("Expected %+v\nGot %+v", goodClu, cluster)
 	}
 
-	cluster, err = createCluster(context.TODO(), client, aws.String("badclu"))
+	cluster, err = createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("badclu")})
 	if err == nil {
 		t.Fatal("expected error from get cluster, got", err, cluster)
 	}


### PR DESCRIPTION
Add a default execution role item to the config [per account] to avoid having to pass it for orchestration actions.