### PR TITLE
Create custom IAM role for each cluster

### DIFF
--- a/api/handlers_orchestration.go
+++ b/api/handlers_orchestration.go
@@ -72,10 +72,6 @@ func (s *server) ServiceOrchestrationCreateHandler(w http.ResponseWriter, r *htt
 		orchestration.DefaultSubnets = sus
 	}
 
-	// if ecsService.DefaultExecutionRoleArn != "" {
-	// 	orchestration.DefaultExecutionRoleArn = aws.String(ecsService.DefaultExecutionRoleArn)
-	// }
-
 	body, _ := ioutil.ReadAll(r.Body)
 	log.Debugf("new service orchestration request body: %s", body)
 

--- a/api/server.go
+++ b/api/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/YaleSpinup/ecs-api/cloudwatchlogs"
 	"github.com/YaleSpinup/ecs-api/common"
 	"github.com/YaleSpinup/ecs-api/ecs"
+	"github.com/YaleSpinup/ecs-api/iam"
 	"github.com/YaleSpinup/ecs-api/secretsmanager"
 	"github.com/YaleSpinup/ecs-api/servicediscovery"
 	"github.com/gorilla/handlers"
@@ -22,6 +23,7 @@ type server struct {
 	sdServices     map[string]servicediscovery.ServiceDiscovery
 	smServices     map[string]secretsmanager.SecretsManager
 	ecsServices    map[string]ecs.ECS
+	iamServices    map[string]iam.IAM
 	cwLogsServices map[string]cloudwatchlogs.CloudWatchLogs
 	router         *mux.Router
 	version        common.Version
@@ -35,6 +37,7 @@ func NewServer(config common.Config) error {
 		ecsServices:    make(map[string]ecs.ECS),
 		cwLogsServices: make(map[string]cloudwatchlogs.CloudWatchLogs),
 		smServices:     make(map[string]secretsmanager.SecretsManager),
+		iamServices:    make(map[string]iam.IAM),
 		router:         mux.NewRouter(),
 		version:        config.Version,
 		org:            config.Org,
@@ -46,6 +49,7 @@ func NewServer(config common.Config) error {
 		s.ecsServices[name] = ecs.NewSession(c)
 		s.cwLogsServices[name] = cloudwatchlogs.NewSession(c)
 		s.smServices[name] = secretsmanager.NewSession(c)
+		s.iamServices[name] = iam.NewSession(c)
 	}
 
 	publicURLs := map[string]string{

--- a/common/config.go
+++ b/common/config.go
@@ -20,13 +20,12 @@ type Config struct {
 
 // Account is the configuration for an individual account
 type Account struct {
-	Region                  string
-	Akid                    string
-	Secret                  string
-	DefaultSgs              []string
-	DefaultSubnets          []string
-	DefaultExecutionRoleArn string
-	DefaultKmsKeyId         string
+	Region          string
+	Akid            string
+	Secret          string
+	DefaultSgs      []string
+	DefaultSubnets  []string
+	DefaultKmsKeyId string
 }
 
 // Version carries around the API version information

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -10,19 +10,18 @@ var testConfig = []byte(
 	`{
 		"listenAddress": ":8000",
 		"accounts": {
-		  "provider1": {
-			"region": "us-east-1",
-			"akid": "key1",
-			"secret": "secret1",
-			"defaultSgs": ["sg-xxxxxx", "sg-yyyyyy"],
-			"defaultSubnets": ["subnet-xxxxxxx", "subnet-yyyyyy"],
-			"defaultExecutionRoleArn": "arn:aws:iam::1111111111111:role/ecsTaskExecutionRole"
-		  },
-		  "provider2": {
-			"region": "us-west-1",
-			"akid": "key2",
-			"secret": "secret2"
-		  }
+			"provider1": {
+				"region": "us-east-1",
+				"akid": "key1",
+				"secret": "secret1",
+				"defaultSgs": ["sg-xxxxxx", "sg-yyyyyy"],
+				"defaultSubnets": ["subnet-xxxxxxx", "subnet-yyyyyy"]
+			},
+			"provider2": {
+				"region": "us-west-1",
+				"akid": "key2",
+				"secret": "secret2"
+			}
 		},
 		"token": "SEKRET",
 		"logLevel": "info",
@@ -34,12 +33,11 @@ func TestReadConfig(t *testing.T) {
 		ListenAddress: ":8000",
 		Accounts: map[string]Account{
 			"provider1": Account{
-				Region:                  "us-east-1",
-				Akid:                    "key1",
-				Secret:                  "secret1",
-				DefaultSgs:              []string{"sg-xxxxxx", "sg-yyyyyy"},
-				DefaultSubnets:          []string{"subnet-xxxxxxx", "subnet-yyyyyy"},
-				DefaultExecutionRoleArn: "arn:aws:iam::1111111111111:role/ecsTaskExecutionRole",
+				Region:         "us-east-1",
+				Akid:           "key1",
+				Secret:         "secret1",
+				DefaultSgs:     []string{"sg-xxxxxx", "sg-yyyyyy"},
+				DefaultSubnets: []string{"subnet-xxxxxxx", "subnet-yyyyyy"},
 			},
 			"provider2": Account{
 				Region: "us-west-1",
@@ -49,7 +47,7 @@ func TestReadConfig(t *testing.T) {
 		},
 		Token:    "SEKRET",
 		LogLevel: "info",
-		Org: "test",
+		Org:      "test",
 	}
 
 	actualConfig, err := ReadConfig(bytes.NewReader(testConfig))

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -7,7 +7,6 @@
       "secret": "xxxxxxxx",
       "defaultSgs": ["sg-xxxxxx", "sg-yyyyyy"],
       "defaultSubnets": ["subnet-xxxxxxx", "subnet-yyyyyy"],
-      "defaultExecutionRoleArn": "arn:aws:iam::1111111111111:role/ecsTaskExecutionRole",
       "defaultKmsKeyId": "12121212-3333-4444-5555-676767676767"
     },
     "spinup": {
@@ -16,7 +15,6 @@
       "secret": "xxxxxxxx",
       "defaultSgs": ["sg-zzzzzz"],
       "defaultSubnets": ["subnet-zzzzzz"],
-      "defaultExecutionRoleArn": "arn:aws:iam::22222222222222:role/ecsTaskExecutionRole",
       "defaultKmsKeyId": "90909090-8888-7777-6666-545454545454"
     }
   },

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -7,7 +7,6 @@
       "secret": "{{ .spinup_secret }}",
       "defaultSgs": ["{{ .default_sg }}"],
       "defaultSubnets": ["{{ .default_subnet }}"],
-      "defaultExecutionRoleArn": "{{ .default_exection_role_arn }}",
       "defaultKmsKeyId": "{{ .default_kms_key_id }}"
     }
   },

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -11,10 +11,9 @@ import (
 
 // ECS is a wrapper around the aws ECS service with some default config info
 type ECS struct {
-	Service                 *ecs.ECS
-	DefaultSgs              []string
-	DefaultSubnets          []string
-	DefaultExecutionRoleArn string
+	Service        *ecs.ECS
+	DefaultSgs     []string
+	DefaultSubnets []string
 }
 
 // NewSession creates a new ECS session
@@ -29,7 +28,6 @@ func NewSession(account common.Account) ECS {
 
 	e.DefaultSgs = account.DefaultSgs
 	e.DefaultSubnets = account.DefaultSubnets
-	e.DefaultExecutionRoleArn = account.DefaultExecutionRoleArn
 
 	return e
 }

--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/aws/aws-sdk-go v1.20.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.20.10 h1:wrwdNYb9Xe1ahNEEXl0M/O/g/dmonWag1TFAKVNQulM=
 github.com/aws/aws-sdk-go v1.20.11 h1:xDc2f/8KmwPW7WkuB0kDUCEP4jpx1PIMMMZkav6cbU4=
 github.com/aws/aws-sdk-go v1.20.12 h1:xV7xfLSkiqd7JOnLlfER+Jz8kI98rAGJvtXssYkCRs4=
+github.com/aws/aws-sdk-go v1.24.6 h1:QmBKT5yfcWuMz6+n53YFl6uiaTCSjhcEk1I5jIRU+uU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=

--- a/iam/errors.go
+++ b/iam/errors.go
@@ -1,0 +1,236 @@
+package iam
+
+import (
+	"github.com/YaleSpinup/ecs-api/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/pkg/errors"
+)
+
+func ErrCode(msg string, err error) error {
+	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
+		switch aerr.Code() {
+		case
+
+			// ErrCodeConcurrentModificationException for service response error code
+			// "ConcurrentModification".
+			//
+			// The request was rejected because multiple requests to change this object
+			// were submitted simultaneously. Wait a few minutes and submit your request
+			// again.
+			iam.ErrCodeConcurrentModificationException,
+
+			// ErrCodeDeleteConflictException for service response error code
+			// "DeleteConflict".
+			//
+			// The request was rejected because it attempted to delete a resource that has
+			// attached subordinate entities. The error message describes these entities.
+			iam.ErrCodeDeleteConflictException,
+
+			// ErrCodeDuplicateCertificateException for service response error code
+			// "DuplicateCertificate".
+			//
+			// The request was rejected because the same certificate is associated with
+			// an IAM user in the account.
+			iam.ErrCodeDuplicateCertificateException,
+
+			// ErrCodeDuplicateSSHPublicKeyException for service response error code
+			// "DuplicateSSHPublicKey".
+			//
+			// The request was rejected because the SSH public key is already associated
+			// with the specified IAM user.
+			iam.ErrCodeDuplicateSSHPublicKeyException,
+
+			// ErrCodeEntityAlreadyExistsException for service response error code
+			// "EntityAlreadyExists".
+			//
+			// The request was rejected because it attempted to create a resource that already
+			// exists.
+			iam.ErrCodeEntityAlreadyExistsException:
+
+			return apierror.New(apierror.ErrConflict, msg, aerr)
+
+		case
+			// ErrCodeCredentialReportExpiredException for service response error code
+			// "ReportExpired".
+			//
+			// The request was rejected because the most recent credential report has expired.
+			// To generate a new credential report, use GenerateCredentialReport. For more
+			// information about credential report expiration, see Getting Credential Reports
+			// (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html)
+			// in the IAM User Guide.
+			iam.ErrCodeCredentialReportExpiredException,
+
+			// ErrCodeCredentialReportNotPresentException for service response error code
+			// "ReportNotPresent".
+			//
+			// The request was rejected because the credential report does not exist. To
+			// generate a credential report, use GenerateCredentialReport.
+			iam.ErrCodeCredentialReportNotPresentException,
+
+			// ErrCodeCredentialReportNotReadyException for service response error code
+			// "ReportInProgress".
+			//
+			// The request was rejected because the credential report is still being generated.
+			iam.ErrCodeCredentialReportNotReadyException,
+
+			// ErrCodeEntityTemporarilyUnmodifiableException for service response error code
+			// "EntityTemporarilyUnmodifiable".
+			//
+			// The request was rejected because it referenced an entity that is temporarily
+			// unmodifiable, such as a user name that was deleted and then recreated. The
+			// error indicates that the request is likely to succeed if you try again after
+			// waiting several minutes. The error message describes the entity.
+			iam.ErrCodeEntityTemporarilyUnmodifiableException,
+
+			// ErrCodeInvalidAuthenticationCodeException for service response error code
+			// "InvalidAuthenticationCode".
+			//
+			// The request was rejected because the authentication code was not recognized.
+			// The error message describes the specific error.
+			iam.ErrCodeInvalidAuthenticationCodeException,
+
+			// ErrCodeInvalidCertificateException for service response error code
+			// "InvalidCertificate".
+			//
+			// The request was rejected because the certificate is invalid.
+			iam.ErrCodeInvalidCertificateException,
+
+			// ErrCodeInvalidInputException for service response error code
+			// "InvalidInput".
+			//
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			iam.ErrCodeInvalidInputException,
+
+			// ErrCodeInvalidPublicKeyException for service response error code
+			// "InvalidPublicKey".
+			//
+			// The request was rejected because the public key is malformed or otherwise
+			// invalid.
+			iam.ErrCodeInvalidPublicKeyException,
+
+			// ErrCodeInvalidUserTypeException for service response error code
+			// "InvalidUserType".
+			//
+			// The request was rejected because the type of user for the transaction was
+			// incorrect.
+			iam.ErrCodeInvalidUserTypeException,
+
+			// ErrCodeKeyPairMismatchException for service response error code
+			// "KeyPairMismatch".
+			//
+			// The request was rejected because the public key certificate and the private
+			// key do not match.
+			iam.ErrCodeKeyPairMismatchException,
+
+			// ErrCodeMalformedCertificateException for service response error code
+			// "MalformedCertificate".
+			//
+			// The request was rejected because the certificate was malformed or expired.
+			// The error message describes the specific error.
+			iam.ErrCodeMalformedCertificateException,
+
+			// ErrCodeMalformedPolicyDocumentException for service response error code
+			// "MalformedPolicyDocument".
+			//
+			// The request was rejected because the policy document was malformed. The error
+			// message describes the specific error.
+			iam.ErrCodeMalformedPolicyDocumentException,
+
+			// ErrCodePasswordPolicyViolationException for service response error code
+			// "PasswordPolicyViolation".
+			//
+			// The request was rejected because the provided password did not meet the requirements
+			// imposed by the account password policy.
+			iam.ErrCodePasswordPolicyViolationException,
+
+			// ErrCodePolicyEvaluationException for service response error code
+			// "PolicyEvaluation".
+			//
+			// The request failed because a provided policy could not be successfully evaluated.
+			// An additional detailed message indicates the source of the failure.
+			iam.ErrCodePolicyEvaluationException,
+
+			// ErrCodePolicyNotAttachableException for service response error code
+			// "PolicyNotAttachable".
+			//
+			// The request failed because AWS service role policies can only be attached
+			// to the service-linked role for that service.
+			iam.ErrCodePolicyNotAttachableException,
+
+			// ErrCodeUnrecognizedPublicKeyEncodingException for service response error code
+			// "UnrecognizedPublicKeyEncoding".
+			//
+			// The request was rejected because the public key encoding format is unsupported
+			// or unrecognized.
+			iam.ErrCodeUnrecognizedPublicKeyEncodingException:
+
+			return apierror.New(apierror.ErrBadRequest, msg, aerr)
+
+		case
+			// ErrCodeLimitExceededException for service response error code
+			// "LimitExceeded".
+			//
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			iam.ErrCodeLimitExceededException:
+
+			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
+
+		case
+			// ErrCodeNoSuchEntityException for service response error code
+			// "NoSuchEntity".
+			//
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			iam.ErrCodeNoSuchEntityException:
+
+			return apierror.New(apierror.ErrNotFound, msg, aerr)
+
+		case
+			// ErrCodeReportGenerationLimitExceededException for service response error code
+			// "ReportGenerationLimitExceeded".
+			//
+			// The request failed because the maximum number of concurrent requests for
+			// this account are already running.
+			iam.ErrCodeReportGenerationLimitExceededException:
+
+			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
+
+		case
+			// ErrCodeUnmodifiableEntityException for service response error code
+			// "UnmodifiableEntity".
+			//
+			// The request was rejected because only the service that depends on the service-linked
+			// role can modify or delete the role on your behalf. The error message includes
+			// the name of the service that depends on this service-linked role. You must
+			// request the change through that service.
+			iam.ErrCodeUnmodifiableEntityException:
+
+			return apierror.New(apierror.ErrInternalError, msg, aerr)
+
+		case
+			// ErrCodeServiceFailureException for service response error code
+			// "ServiceFailure".
+			//
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			iam.ErrCodeServiceFailureException,
+
+			// ErrCodeServiceNotSupportedException for service response error code
+			// "NotSupportedService".
+			//
+			// The specified service does not support service-specific credentials.
+			iam.ErrCodeServiceNotSupportedException:
+
+			return apierror.New(apierror.ErrServiceUnavailable, msg, aerr)
+
+		default:
+			m := msg + ": " + aerr.Message()
+			return apierror.New(apierror.ErrBadRequest, m, aerr)
+		}
+	}
+
+	return apierror.New(apierror.ErrInternalError, msg, err)
+}

--- a/iam/errors.go
+++ b/iam/errors.go
@@ -7,11 +7,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrCode converts AWS errors to standardized ecs-api errors
 func ErrCode(msg string, err error) error {
 	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
 		switch aerr.Code() {
 		case
-
 			// ErrCodeConcurrentModificationException for service response error code
 			// "ConcurrentModification".
 			//
@@ -47,9 +47,7 @@ func ErrCode(msg string, err error) error {
 			// The request was rejected because it attempted to create a resource that already
 			// exists.
 			iam.ErrCodeEntityAlreadyExistsException:
-
 			return apierror.New(apierror.ErrConflict, msg, aerr)
-
 		case
 			// ErrCodeCredentialReportExpiredException for service response error code
 			// "ReportExpired".
@@ -165,9 +163,7 @@ func ErrCode(msg string, err error) error {
 			// The request was rejected because the public key encoding format is unsupported
 			// or unrecognized.
 			iam.ErrCodeUnrecognizedPublicKeyEncodingException:
-
 			return apierror.New(apierror.ErrBadRequest, msg, aerr)
-
 		case
 			// ErrCodeLimitExceededException for service response error code
 			// "LimitExceeded".
@@ -175,9 +171,7 @@ func ErrCode(msg string, err error) error {
 			// The request was rejected because it attempted to create resources beyond
 			// the current AWS account limits. The error message describes the limit exceeded.
 			iam.ErrCodeLimitExceededException:
-
 			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
-
 		case
 			// ErrCodeNoSuchEntityException for service response error code
 			// "NoSuchEntity".
@@ -185,9 +179,7 @@ func ErrCode(msg string, err error) error {
 			// The request was rejected because it referenced a resource entity that does
 			// not exist. The error message describes the resource.
 			iam.ErrCodeNoSuchEntityException:
-
 			return apierror.New(apierror.ErrNotFound, msg, aerr)
-
 		case
 			// ErrCodeReportGenerationLimitExceededException for service response error code
 			// "ReportGenerationLimitExceeded".
@@ -195,9 +187,7 @@ func ErrCode(msg string, err error) error {
 			// The request failed because the maximum number of concurrent requests for
 			// this account are already running.
 			iam.ErrCodeReportGenerationLimitExceededException:
-
 			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
-
 		case
 			// ErrCodeUnmodifiableEntityException for service response error code
 			// "UnmodifiableEntity".
@@ -207,9 +197,7 @@ func ErrCode(msg string, err error) error {
 			// the name of the service that depends on this service-linked role. You must
 			// request the change through that service.
 			iam.ErrCodeUnmodifiableEntityException:
-
 			return apierror.New(apierror.ErrInternalError, msg, aerr)
-
 		case
 			// ErrCodeServiceFailureException for service response error code
 			// "ServiceFailure".
@@ -223,9 +211,7 @@ func ErrCode(msg string, err error) error {
 			//
 			// The specified service does not support service-specific credentials.
 			iam.ErrCodeServiceNotSupportedException:
-
 			return apierror.New(apierror.ErrServiceUnavailable, msg, aerr)
-
 		default:
 			m := msg + ": " + aerr.Message()
 			return apierror.New(apierror.ErrBadRequest, m, aerr)

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -1,0 +1,95 @@
+package iam
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/YaleSpinup/ecs-api/common"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// PolicyStatement is an individual IAM Policy statement
+type PolicyStatement struct {
+	Effect    string
+	Principal string `json:",omitempty"`
+	Action    []string
+	Resource  []string
+}
+
+// PolicyDoc collects the policy statements
+type PolicyDoc struct {
+	Version   string
+	Statement []PolicyStatement
+}
+
+// IAM is a wrapper around the aws IAM service with some default config info
+type IAM struct {
+	Service         iamiface.IAMAPI
+	DefaultKmsKeyID string
+}
+
+// NewSession creates a new IAM session
+func NewSession(account common.Account) IAM {
+	i := IAM{}
+	log.Infof("creating new aws session for IAM with key id %s in region %s", account.Akid, account.Region)
+	sess := session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(account.Akid, account.Secret, ""),
+		Region:      aws.String(account.Region),
+	}))
+
+	i.Service = iam.New(sess)
+	i.DefaultKmsKeyID = account.DefaultKmsKeyId
+
+	return i
+}
+
+// DefaultTaskExecutionPolicy generates the default policy for ECS task execution
+func (i *IAM) DefaultTaskExecutionPolicy(cluster *string) ([]byte, error) {
+	c := aws.StringValue(cluster)
+	log.Debugf("generating default task execution policy for cluster %s", c)
+
+	policyDoc, err := json.Marshal(PolicyDoc{
+		Version: "2012-10-17",
+		Statement: []PolicyStatement{
+			PolicyStatement{
+				Effect: "Allow",
+				Action: []string{
+					"ecr:GetAuthorizationToken",
+					"ecr:BatchCheckLayerAvailability",
+					"ecr:GetDownloadUrlForLayer",
+					"ecr:BatchGetImage",
+					"logs:CreateLogGroup",
+					"logs:CreateLogStream",
+					"logs:PutLogEvents",
+				},
+				Resource: []string{"*"},
+			},
+			PolicyStatement{
+				Effect: "Allow",
+				Action: []string{
+					"secretsmanager:GetSecretValue",
+					"ssm:GetParameters",
+					"kms:Decrypt",
+				},
+				Resource: []string{
+					"arn:aws:secretsmanager:::secret:*",
+					fmt.Sprintf("arn:aws:ssm:::parameter/*"),
+					fmt.Sprintf("arn:aws:kms:::key/%s", i.DefaultKmsKeyID),
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		log.Errorf("failed to generate default task execution policy for cluster %s: %s", c, err)
+		return []byte{}, err
+	}
+
+	return policyDoc, nil
+}

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -142,8 +142,7 @@ func (i *IAM) DefaultTaskExecutionRole(ctx context.Context, path string) (*strin
 		RoleName:                 aws.String(role),
 	})
 	if err != nil {
-		log.Errorf("failed to create role %s: %s", role, err.Error())
-		return nil, err
+		return nil, ErrCode("failed to create role", err)
 	}
 
 	// attach default role policy to the role
@@ -153,8 +152,7 @@ func (i *IAM) DefaultTaskExecutionRole(ctx context.Context, path string) (*strin
 		RoleName:       aws.String(role),
 	})
 	if err != nil {
-		log.Errorf("failed to attach policy to role %s: %s", role, err.Error())
-		return nil, err
+		return nil, ErrCode("failed to attach policy to role", err)
 	}
 
 	return roleOutput.Role.Arn, nil

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -1,0 +1,91 @@
+package iam
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/YaleSpinup/ecs-api/common"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+)
+
+var testTime = time.Now()
+
+// mockIAMClient is a fake IAM client
+type mockIAMClient struct {
+	iamiface.IAMAPI
+	t   *testing.T
+	err error
+}
+
+func newMockIAMClient(t *testing.T, err error) iamiface.IAMAPI {
+	return &mockIAMClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	e := NewSession(common.Account{})
+	to := reflect.TypeOf(e).String()
+	if to != "iam.IAM" {
+		t.Errorf("expected type to be 'iam.IAM', got %s", to)
+	}
+}
+
+var cluster = "super-why"
+
+var i = &IAM{
+	DefaultKmsKeyID: "123",
+}
+
+var defaultPolicyDoc = PolicyDoc{
+	Version: "2012-10-17",
+	Statement: []PolicyStatement{
+		PolicyStatement{
+			Effect: "Allow",
+			Action: []string{
+				"ecr:GetAuthorizationToken",
+				"ecr:BatchCheckLayerAvailability",
+				"ecr:GetDownloadUrlForLayer",
+				"ecr:BatchGetImage",
+				"logs:CreateLogGroup",
+				"logs:CreateLogStream",
+				"logs:PutLogEvents",
+			},
+			Resource: []string{"*"},
+		},
+		PolicyStatement{
+			Effect: "Allow",
+			Action: []string{
+				"secretsmanager:GetSecretValue",
+				"ssm:GetParameters",
+				"kms:Decrypt",
+			},
+			Resource: []string{
+				"arn:aws:secretsmanager:::secret:*",
+				fmt.Sprintf("arn:aws:ssm:::parameter/*"),
+				fmt.Sprintf("arn:aws:kms:::key/%s", i.DefaultKmsKeyID),
+			},
+		},
+	},
+}
+
+func TestDefaultTaskExecutionPolicy(t *testing.T) {
+	p, err := json.Marshal(defaultPolicyDoc)
+	if err != nil {
+		t.Errorf("expected to marshall defaultPolicyDoc with nil error, got %s", err)
+	}
+
+	policyBytes, err := i.DefaultTaskExecutionPolicy(&cluster)
+	if err != nil {
+		t.Errorf("expected DefaultTaskExecutionPolicy to return nil error, got %s", err)
+	}
+
+	if !bytes.Equal(policyBytes, p) {
+		t.Errorf("expected: %s\ngot: %s", defaultPolicyDoc, policyBytes)
+	}
+}

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -36,7 +36,7 @@ func TestNewSession(t *testing.T) {
 	}
 }
 
-var cluster = "super-why"
+var path = "org/super-why"
 
 var i = &IAM{
 	DefaultKmsKeyID: "123",
@@ -67,7 +67,7 @@ var defaultPolicyDoc = PolicyDoc{
 			},
 			Resource: []string{
 				"arn:aws:secretsmanager:::secret:*",
-				fmt.Sprintf("arn:aws:ssm:::parameter/*"),
+				fmt.Sprintf("arn:aws:ssm:::parameter/%s/*", path),
 				fmt.Sprintf("arn:aws:kms:::key/%s", i.DefaultKmsKeyID),
 			},
 		},
@@ -80,7 +80,7 @@ func TestDefaultTaskExecutionPolicy(t *testing.T) {
 		t.Errorf("expected to marshall defaultPolicyDoc with nil error, got %s", err)
 	}
 
-	policyBytes, err := i.DefaultTaskExecutionPolicy(&cluster)
+	policyBytes, err := i.DefaultTaskExecutionPolicy(path)
 	if err != nil {
 		t.Errorf("expected DefaultTaskExecutionPolicy to return nil error, got %s", err)
 	}

--- a/iam/role.go
+++ b/iam/role.go
@@ -2,17 +2,15 @@ package iam
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/YaleSpinup/ecs-api/apierror"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	log "github.com/sirupsen/logrus"
 )
 
-// CreateRole handles creating IAM role
+// CreateRole handles creating an IAM role
 func (i *IAM) CreateRole(ctx context.Context, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	if input == nil {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
@@ -22,47 +20,13 @@ func (i *IAM) CreateRole(ctx context.Context, input *iam.CreateRoleInput) (*iam.
 
 	output, err := i.Service.CreateRoleWithContext(ctx, input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			// * ErrCodeInvalidInputException "InvalidInput"
-			// The request was rejected because an invalid or out-of-range value was supplied
-			// for an input parameter.
-			// * ErrCodeMalformedPolicyDocumentException "MalformedPolicyDocument"
-			// The request was rejected because the policy document was malformed. The error
-			// message describes the specific error.
-			case iam.ErrCodeInvalidInputException, iam.ErrCodeMalformedPolicyDocumentException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
-			// * ErrCodeLimitExceededException "LimitExceeded"
-			// The request was rejected because it attempted to create resources beyond
-			// the current AWS account limits. The error message describes the limit exceeded.
-			case iam.ErrCodeLimitExceededException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
-			// * ErrCodeEntityAlreadyExistsException "EntityAlreadyExists"
-			// The request was rejected because it attempted to create a resource that already
-			// exists.
-			case iam.ErrCodeEntityAlreadyExistsException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrConflict, msg, err)
-			// * ErrCodeServiceFailureException "ServiceFailure"
-			// The request processing has failed because of an unknown error, exception
-			// or failure.
-			case iam.ErrCodeServiceFailureException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
-			default:
-				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
-			}
-		}
-
-		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+		return nil, ErrCode("failed to create role", err)
 	}
 
 	return output, nil
 }
 
-// DeleteRole handles deleting IAM role
+// DeleteRole handles deleting an IAM role
 func (i *IAM) DeleteRole(ctx context.Context, input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
 	if input == nil || aws.StringValue(input.RoleName) == "" {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
@@ -72,43 +36,7 @@ func (i *IAM) DeleteRole(ctx context.Context, input *iam.DeleteRoleInput) (*iam.
 
 	output, err := i.Service.DeleteRoleWithContext(ctx, input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			// * ErrCodeNoSuchEntityException "NoSuchEntity"
-			// The request was rejected because it referenced a resource entity that does
-			// not exist. The error message describes the resource.
-			case iam.ErrCodeNoSuchEntityException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrNotFound, msg, err)
-			// * ErrCodeLimitExceededException "LimitExceeded"
-			// The request was rejected because it attempted to create resources beyond
-			// the current AWS account limits. The error message describes the limit exceeded.
-			case iam.ErrCodeLimitExceededException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
-			// * ErrCodeInvalidInputException "InvalidInput"
-			// The request was rejected because an invalid or out-of-range value was supplied
-			// for an input parameter.
-			case iam.ErrCodeInvalidInputException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
-			// * ErrCodeDeleteConflictException "DeleteConflict"
-			// The request was rejected because it attempted to delete a resource that has
-			// attached subordinate entities. The error message describes these entities.
-			case iam.ErrCodeDeleteConflictException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrConflict, msg, err)
-			// * ErrCodeServiceFailureException "ServiceFailure"
-			// The request processing has failed because of an unknown error, exception
-			// or failure.
-			case iam.ErrCodeServiceFailureException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
-			default:
-				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
-			}
-		}
-		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+		return nil, ErrCode("failed to delete role", err)
 	}
 
 	return output, nil
@@ -124,19 +52,7 @@ func (i *IAM) GetRole(ctx context.Context, input *iam.GetRoleInput) (*iam.GetRol
 
 	output, err := i.Service.GetRoleWithContext(ctx, input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case iam.ErrCodeNoSuchEntityException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrNotFound, msg, err)
-			case iam.ErrCodeServiceFailureException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
-			default:
-				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
-			}
-		}
-		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+		return nil, ErrCode("failed to get role", err)
 	}
 
 	return output, nil
@@ -152,41 +68,7 @@ func (i *IAM) PutRolePolicy(ctx context.Context, input *iam.PutRolePolicyInput) 
 
 	output, err := i.Service.PutRolePolicyWithContext(ctx, input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			// * ErrCodeInvalidInputException "InvalidInput"
-			// The request was rejected because an invalid or out-of-range value was supplied
-			// for an input parameter.
-			// * ErrCodeMalformedPolicyDocumentException "MalformedPolicyDocument"
-			// The request was rejected because the policy document was malformed. The error
-			// message describes the specific error.
-			case iam.ErrCodeInvalidInputException, iam.ErrCodeMalformedPolicyDocumentException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
-			// * ErrCodeLimitExceededException "LimitExceeded"
-			// The request was rejected because it attempted to create resources beyond
-			// the current AWS account limits. The error message describes the limit exceeded.
-			case iam.ErrCodeLimitExceededException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
-			// * ErrCodeNoSuchEntityException "NoSuchEntityException"
-			// The request was rejected because it referenced an entity that does not exist.
-			// The error code describes the entity.
-			case iam.ErrCodeNoSuchEntityException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrNotFound, msg, err)
-			// * ErrCodeServiceFailureException "ServiceFailure"
-			// The request processing has failed because of an unknown error, exception
-			// or failure.
-			case iam.ErrCodeServiceFailureException:
-				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
-				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
-			default:
-				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
-			}
-		}
-
-		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+		return nil, ErrCode("failed to attach policy to role", err)
 	}
 
 	return output, nil

--- a/iam/role.go
+++ b/iam/role.go
@@ -1,0 +1,115 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YaleSpinup/ecs-api/apierror"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	log "github.com/sirupsen/logrus"
+)
+
+// CreateRole handles creating IAM role
+func (i *IAM) CreateRole(ctx context.Context, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("creating iam role: %s", *input.RoleName)
+
+	output, err := i.Service.CreateRoleWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeInvalidInputException "InvalidInput"
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			// * ErrCodeMalformedPolicyDocumentException "MalformedPolicyDocument"
+			// The request was rejected because the policy document was malformed. The error
+			// message describes the specific error.
+			case iam.ErrCodeInvalidInputException, iam.ErrCodeMalformedPolicyDocumentException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeEntityAlreadyExistsException "EntityAlreadyExists"
+			// The request was rejected because it attempted to create a resource that already
+			// exists.
+			case iam.ErrCodeEntityAlreadyExistsException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}
+
+// DeleteRole handles deleting IAM role
+func (i *IAM) DeleteRole(ctx context.Context, input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+	if input == nil || aws.StringValue(input.RoleName) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting iam role %s", aws.StringValue(input.RoleName))
+
+	output, err := i.Service.DeleteRoleWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeNoSuchEntityException "NoSuchEntity"
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			case iam.ErrCodeNoSuchEntityException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrNotFound, msg, err)
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeInvalidInputException "InvalidInput"
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			case iam.ErrCodeInvalidInputException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
+			// * ErrCodeDeleteConflictException "DeleteConflict"
+			// The request was rejected because it attempted to delete a resource that has
+			// attached subordinate entities. The error message describes these entities.
+			case iam.ErrCodeDeleteConflictException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}

--- a/iam/role.go
+++ b/iam/role.go
@@ -60,7 +60,7 @@ func (i *IAM) GetRole(ctx context.Context, input *iam.GetRoleInput) (*iam.GetRol
 
 // PutRolePolicy handles attaching an inline policy to IAM role
 func (i *IAM) PutRolePolicy(ctx context.Context, input *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
-	if input == nil {
+	if input == nil || aws.StringValue(input.RoleName) == "" || aws.StringValue(input.PolicyDocument) == "" || aws.StringValue(input.PolicyName) == "" {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 

--- a/iam/role.go
+++ b/iam/role.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CreateRole handles creating an IAM role
-func (i *IAM) CreateRole(ctx context.Context, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
+func (i *IAM) CreateRole(ctx context.Context, input *iam.CreateRoleInput) (*iam.Role, error) {
 	if input == nil {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
@@ -23,27 +23,27 @@ func (i *IAM) CreateRole(ctx context.Context, input *iam.CreateRoleInput) (*iam.
 		return nil, ErrCode("failed to create role", err)
 	}
 
-	return output, nil
+	return output.Role, nil
 }
 
 // DeleteRole handles deleting an IAM role
-func (i *IAM) DeleteRole(ctx context.Context, input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+func (i *IAM) DeleteRole(ctx context.Context, input *iam.DeleteRoleInput) error {
 	if input == nil || aws.StringValue(input.RoleName) == "" {
-		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
 	log.Infof("deleting iam role %s", aws.StringValue(input.RoleName))
 
-	output, err := i.Service.DeleteRoleWithContext(ctx, input)
+	_, err := i.Service.DeleteRoleWithContext(ctx, input)
 	if err != nil {
-		return nil, ErrCode("failed to delete role", err)
+		return ErrCode("failed to delete role", err)
 	}
 
-	return output, nil
+	return nil
 }
 
 // GetRole handles getting information about an IAM role
-func (i *IAM) GetRole(ctx context.Context, input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+func (i *IAM) GetRole(ctx context.Context, input *iam.GetRoleInput) (*iam.Role, error) {
 	if input == nil || aws.StringValue(input.RoleName) == "" {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
@@ -55,21 +55,21 @@ func (i *IAM) GetRole(ctx context.Context, input *iam.GetRoleInput) (*iam.GetRol
 		return nil, ErrCode("failed to get role", err)
 	}
 
-	return output, nil
+	return output.Role, nil
 }
 
 // PutRolePolicy handles attaching an inline policy to IAM role
-func (i *IAM) PutRolePolicy(ctx context.Context, input *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+func (i *IAM) PutRolePolicy(ctx context.Context, input *iam.PutRolePolicyInput) error {
 	if input == nil || aws.StringValue(input.RoleName) == "" || aws.StringValue(input.PolicyDocument) == "" || aws.StringValue(input.PolicyName) == "" {
-		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
 	log.Infof("attaching inline policy to iam role: %s", *input.RoleName)
 
-	output, err := i.Service.PutRolePolicyWithContext(ctx, input)
+	_, err := i.Service.PutRolePolicyWithContext(ctx, input)
 	if err != nil {
-		return nil, ErrCode("failed to attach policy to role", err)
+		return ErrCode("failed to attach policy to role", err)
 	}
 
-	return output, nil
+	return nil
 }

--- a/iam/role_test.go
+++ b/iam/role_test.go
@@ -162,7 +162,7 @@ func TestCreateRole(t *testing.T) {
 	}
 
 	// test some other, unexpected AWS error
-	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeDeleteConflictException, "delete conflict", nil)
+	i.Service.(*mockIAMClient).err = awserr.New("UnknownThingyBrokeYo", "ThingyBroke", nil)
 	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
 		Path:                     aws.String("/"),
@@ -285,7 +285,7 @@ func TestDeleteRole(t *testing.T) {
 	}
 
 	// test some other, unexpected AWS error
-	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeEntityAlreadyExistsException, "role exists", nil)
+	i.Service.(*mockIAMClient).err = awserr.New("UnknownThingyBrokeYo", "ThingyBroke", nil)
 	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {

--- a/iam/role_test.go
+++ b/iam/role_test.go
@@ -17,10 +17,6 @@ import (
 )
 
 var testRole = iam.Role{
-	// AssumeRolePolicyDocument *string `min:"1" type:"string"`
-	// MaxSessionDuration *int64 `min:"3600" type:"integer"`
-	// PermissionsBoundary *AttachedPermissionsBoundary `type:"structure"`
-	// Tags []*Tag `type:"list"`
 	Arn:         aws.String("arn:aws:iam::12345678910:role/testrole"),
 	CreateDate:  &testTime,
 	Description: aws.String("role model"),
@@ -60,7 +56,7 @@ func TestCreateRole(t *testing.T) {
 	expected := &iam.CreateRoleOutput{Role: &testRole}
 
 	// build the default IAM task execution policy (from the config and known inputs)
-	defaultPolicy, err := i.DefaultTaskExecutionPolicy(aws.String("testCluster"))
+	defaultPolicy, err := i.DefaultTaskExecutionPolicy("org/testCluster")
 	if err != nil {
 		t.Errorf("expected nil error creating default policy doc, got %s", err)
 	}

--- a/iam/role_test.go
+++ b/iam/role_test.go
@@ -1,0 +1,312 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/YaleSpinup/ecs-api/apierror"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+var testRole = iam.Role{
+	// AssumeRolePolicyDocument *string `min:"1" type:"string"`
+	// MaxSessionDuration *int64 `min:"3600" type:"integer"`
+	// PermissionsBoundary *AttachedPermissionsBoundary `type:"structure"`
+	// Tags []*Tag `type:"list"`
+	Arn:         aws.String("arn:aws:iam::12345678910:role/testrole"),
+	CreateDate:  &testTime,
+	Description: aws.String("role model"),
+	Path:        aws.String("/"),
+	RoleId:      aws.String("TESTROLEID123"),
+	RoleName:    aws.String("testrole"),
+}
+
+func (m *mockIAMClient) CreateRoleWithContext(ctx context.Context, input *iam.CreateRoleInput, opts ...request.Option) (*iam.CreateRoleOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.CreateRoleOutput{Role: &iam.Role{
+		Arn:         aws.String(fmt.Sprintf("arn:aws:iam::12345678910:role/%s", *input.RoleName)),
+		CreateDate:  &testTime,
+		Description: input.Description,
+		Path:        input.Path,
+		RoleId:      aws.String(strings.ToUpper(fmt.Sprintf("%sID123", *input.RoleName))),
+		RoleName:    input.RoleName,
+	}}, nil
+}
+
+func (m *mockIAMClient) DeleteRoleWithContext(ctx context.Context, input *iam.DeleteRoleInput, opts ...request.Option) (*iam.DeleteRoleOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.DeleteRoleOutput{}, nil
+}
+
+func TestCreateRole(t *testing.T) {
+	i := IAM{
+		Service:         newMockIAMClient(t, nil),
+		DefaultKmsKeyID: "12345678-90ab-cdef-1234-567890abcdef",
+	}
+
+	// test success
+	expected := &iam.CreateRoleOutput{Role: &testRole}
+
+	// build the default IAM task execution policy (from the config and known inputs)
+	defaultPolicy, err := i.DefaultTaskExecutionPolicy(aws.String("testCluster"))
+	if err != nil {
+		t.Errorf("expected nil error creating default policy doc, got %s", err)
+	}
+
+	out, err := i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Description:              aws.String("role model"),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	if !reflect.DeepEqual(out, expected) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	// test nil input
+	_, err = i.CreateRole(context.TODO(), nil)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeInvalidInputException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeInvalidInputException, "invalid input", nil)
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeMalformedPolicyDocumentException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeMalformedPolicyDocumentException, "malformed policy document", nil)
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeLimitExceededException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeLimitExceededException, "limit exceeded", nil)
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrLimitExceeded {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrLimitExceeded, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeEntityAlreadyExistsException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeEntityAlreadyExistsException, "policy already exists", nil)
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrConflict {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrConflict, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeServiceFailureException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeServiceFailureException, "service failure", nil)
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrServiceUnavailable {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test some other, unexpected AWS error
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeDeleteConflictException, "delete conflict", nil)
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	i.Service.(*mockIAMClient).err = errors.New("things blowing up")
+	_, err = i.CreateRole(context.TODO(), &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("testrole"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}
+
+func TestDeleteRole(t *testing.T) {
+	i := IAM{
+		Service:         newMockIAMClient(t, nil),
+		DefaultKmsKeyID: "12345678-90ab-cdef-1234-567890abcdef",
+	}
+
+	// test success
+	expected := &iam.DeleteRoleOutput{}
+	out, err := i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	if !reflect.DeepEqual(out, expected) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	// test nil input
+	_, err = i.DeleteRole(context.TODO(), nil)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test empty policy arn
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeNoSuchEntityException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeNoSuchEntityException, "not found", nil)
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("rolenotfound")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeLimitExceededException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeLimitExceededException, "limit exceeded", nil)
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrLimitExceeded {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrLimitExceeded, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeInvalidInputException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeInvalidInputException, "invalid input", nil)
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeDeleteConflictException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeDeleteConflictException, "delete conflict", nil)
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrConflict {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrConflict, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeServiceFailureException
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeServiceFailureException, "service failure", nil)
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrServiceUnavailable {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test some other, unexpected AWS error
+	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeEntityAlreadyExistsException, "role exists", nil)
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	i.Service.(*mockIAMClient).err = errors.New("things blowing up")
+	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}

--- a/iam/role_test.go
+++ b/iam/role_test.go
@@ -89,7 +89,7 @@ func TestCreateRole(t *testing.T) {
 	}
 
 	// test success
-	expected := &iam.CreateRoleOutput{Role: &testRole}
+	expected := &testRole
 	out, err := i.CreateRole(context.TODO(), &iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String(string(defaultPolicy)),
 		Description:              aws.String("role model"),
@@ -242,18 +242,13 @@ func TestDeleteRole(t *testing.T) {
 	}
 
 	// test success
-	expected := &iam.DeleteRoleOutput{}
-	out, err := i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err := i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
 
-	if !reflect.DeepEqual(out, expected) {
-		t.Errorf("expected %+v, got %+v", expected, out)
-	}
-
 	// test nil input
-	_, err = i.DeleteRole(context.TODO(), nil)
+	err = i.DeleteRole(context.TODO(), nil)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -263,7 +258,7 @@ func TestDeleteRole(t *testing.T) {
 	}
 
 	// test empty policy arn
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -274,7 +269,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test ErrCodeNoSuchEntityException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeNoSuchEntityException, "NoSuchEntity", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("rolenotfound")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("rolenotfound")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrNotFound {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
@@ -285,7 +280,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test ErrCodeLimitExceededException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeLimitExceededException, "LimitExceeded", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrLimitExceeded {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrLimitExceeded, aerr.Code)
@@ -296,7 +291,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test ErrCodeUnmodifiableEntityException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeUnmodifiableEntityException, "UnmodifiableEntity", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrInternalError {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
@@ -307,7 +302,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test ErrCodeConcurrentModificationException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeConcurrentModificationException, "ConcurrentModification", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrConflict {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrConflict, aerr.Code)
@@ -318,7 +313,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test ErrCodeDeleteConflictException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeDeleteConflictException, "DeleteConflict", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrConflict {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrConflict, aerr.Code)
@@ -329,7 +324,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test ErrCodeServiceFailureException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeServiceFailureException, "ServiceFailure", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrServiceUnavailable {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
@@ -340,7 +335,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test some other, unexpected AWS error
 	i.Service.(*mockIAMClient).err = awserr.New("UnknownThingyBrokeYo", "ThingyBroke", nil)
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -351,7 +346,7 @@ func TestDeleteRole(t *testing.T) {
 
 	// test non-aws error
 	i.Service.(*mockIAMClient).err = errors.New("things blowing up")
-	_, err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
+	err = i.DeleteRole(context.TODO(), &iam.DeleteRoleInput{RoleName: aws.String("testrole")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrInternalError {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
@@ -368,7 +363,7 @@ func TestGetRole(t *testing.T) {
 	}
 
 	// test success
-	expected := &iam.GetRoleOutput{Role: &testRole}
+	expected := &testRole
 	out, err := i.GetRole(context.TODO(), &iam.GetRoleInput{RoleName: aws.String("testrole")})
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
@@ -455,8 +450,7 @@ func TestPutRolePolicy(t *testing.T) {
 	}
 
 	// test success
-	expected := &iam.PutRolePolicyOutput{}
-	out, err := i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -465,12 +459,8 @@ func TestPutRolePolicy(t *testing.T) {
 		t.Errorf("expected nil error, got: %s", err)
 	}
 
-	if !reflect.DeepEqual(out, expected) {
-		t.Errorf("expected %+v, got %+v", expected, out)
-	}
-
 	// test nil input
-	_, err = i.PutRolePolicy(context.TODO(), nil)
+	err = i.PutRolePolicy(context.TODO(), nil)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -480,7 +470,7 @@ func TestPutRolePolicy(t *testing.T) {
 	}
 
 	// test empty role name and empty policy doc
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{})
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -491,7 +481,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test ErrCodeNoSuchEntityException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeNoSuchEntityException, "NoSuchEntity", nil)
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -506,7 +496,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test ErrCodeLimitExceededException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeLimitExceededException, "LimitExceeded", nil)
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -521,7 +511,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test ErrCodeMalformedPolicyDocumentException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeMalformedPolicyDocumentException, "MalformedPolicyDocument", nil)
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -536,7 +526,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test ErrCodeUnmodifiableEntityException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeUnmodifiableEntityException, "UnmodifiableEntity", nil)
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -551,7 +541,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test ErrCodeServiceFailureException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeServiceFailureException, "ServiceFailure", nil)
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -566,7 +556,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test some other, unexpected AWS error
 	i.Service.(*mockIAMClient).err = awserr.New("UnknownThingyBrokeYo", "ThingyBroke", nil)
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),
@@ -581,7 +571,7 @@ func TestPutRolePolicy(t *testing.T) {
 
 	// test non-aws error
 	i.Service.(*mockIAMClient).err = errors.New("things blowing up")
-	_, err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
+	err = i.PutRolePolicy(context.TODO(), &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String(string(testPolicy)),
 		PolicyName:     aws.String("testpolicy"),
 		RoleName:       aws.String("testrole"),

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -40,8 +40,6 @@ var (
 	DefaultSubnets = []*string{}
 	// DefaultSecurityGroups sets a list of default sgs to attach to ENIs
 	DefaultSecurityGroups = []*string{}
-	// DefaultExecutionRoleArn sets the default execution role to give the task definition
-	DefaultExecutionRoleArn = aws.String("")
 	// Org is the organization where this orchestration runs
 	Org = ""
 )
@@ -52,7 +50,6 @@ type Orchestrator struct {
 	ECS *ecs.ECS
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM
 	IAM iam.IAM
-	// IAM iamiface.IAMAPI
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/servicediscovery/#ServiceDiscovery
 	ServiceDiscovery *servicediscovery.ServiceDiscovery
 	// Token is a uniqueness token for calls to AWS
@@ -314,7 +311,7 @@ func (o *Orchestrator) processTaskDefinition(ctx context.Context, input *Service
 				return nil, err
 			}
 
-			input.TaskDefinition.ExecutionRoleArn = roleARN
+			input.TaskDefinition.ExecutionRoleArn = &roleARN
 		}
 
 		taskDefinition, err := createTaskDefinition(ctx, client, input.TaskDefinition)

--- a/orchestration/orchestration_test.go
+++ b/orchestration/orchestration_test.go
@@ -273,5 +273,5 @@ func TestGetServiceDiscovery(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error from bad get service discovery service, got %+v", sd)
 	}
-	t.Log("Got expected error frmo bad service discovery service", err)
+	t.Log("Got expected error from bad service discovery service", err)
 }


### PR DESCRIPTION
This PR adds support for creating/deleting IAM roles. The creation orchestration workflow changes slightly so it will now create a separate IAM role for each cluster instead of using the same default role for all services. This way ECS services in the same cluster can decrypt their own secrets (in SSM Parameter Store) but not secrets belonging to other clusters.