### PR TITLE
Orchestration refactor, private repository credentials, recursive delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,11 @@ HEAD `/v1/ecs/images?image={image}`
 | **404 Not Found**             | image wasn't found (or requires auth) |
 | **500 Internal Server Error** | a server error occurred               |
 
-
 ## Orchestration
 
 The service orchestration endpoints for creating and deleting services allow building and destroying services with one call to the API.
 
-The endpoints are essentially wrapped versions of the ECS and ServiceDiscovery endpoints from AWS.  The endpoint will determine
+The endpoints are wrapped versions of the ECS, IAM, Secrets manager and ServiceDiscovery services from AWS.  The endpoint will determine
 what has been provided and try to take the most logical action.  For example, if you provide `CreateClusterInput`, `RegisterTaskDefinitionInput`
 and `CreateServiceInput`, the API will attempt to create the cluster, then the task definition and then the service using the created
 resources.  If you only provide the `CreateServiceInput` with the task definition name, the cluster name and the service registries, it
@@ -97,15 +96,15 @@ Example request body of new cluster, new task definition, new service registry a
     "cluster": {
         "clustername": "myclu",
         "tags": [
-		    {
-		        "Key": "CreatedBy",
-		        "Value": "netid"
-		    },
-		    {
-		        "Key": "OS",
-		        "Value": "container"
-		    }
-	    ]
+            {
+                "Key": "CreatedBy",
+                "Value": "netid"
+            },
+            {
+                "Key": "OS",
+                "Value": "container"
+            }
+        ]
     },
     "taskdefinition": {
         "family": "webservers",
@@ -156,7 +155,17 @@ Example request body of new cluster, new task definition, new service registry a
           }
         ]
       }
-    }
+    },
+    "credentials": {
+        "webserver": {
+            "Name": "myapp-webserver-cred",
+            "SecretString": "{\"username\" : \"supahman\",\"password\" : \"dontkryptonitemebro\"}",
+            "Description": "myapp-webserver-cred",
+            "tags": [
+                {"Key": "Application", "Value": "myapp" }
+            ]
+        }
+    },
 }
 ```
 

--- a/api/handlers_orchestration.go
+++ b/api/handlers_orchestration.go
@@ -126,14 +126,14 @@ func (s *server) ServiceOrchestrationDeleteHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	sd, ok := s.sdServices[account]
+	sdService, ok := s.sdServices[account]
 	if !ok {
 		msg := fmt.Sprintf("service discovery service not found for account: %s", account)
 		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
 		return
 	}
 
-	sm, ok := s.smServices[account]
+	smService, ok := s.smServices[account]
 	if !ok {
 		msg := fmt.Sprintf("secretsmanager service not found for account: %s", account)
 		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
@@ -142,8 +142,8 @@ func (s *server) ServiceOrchestrationDeleteHandler(w http.ResponseWriter, r *htt
 
 	orchestrator := orchestration.Orchestrator{
 		ECS:              ecsService,
-		ServiceDiscovery: sd,
-		SecretsManager:   sm,
+		ServiceDiscovery: sdService,
+		SecretsManager:   smService,
 		Token:            uuid.NewV4().String(),
 	}
 

--- a/api/handlers_orchestration.go
+++ b/api/handlers_orchestration.go
@@ -47,7 +47,7 @@ func (s *server) ServiceOrchestrationCreateHandler(w http.ResponseWriter, r *htt
 
 	smService, ok := s.smServices[account]
 	if !ok {
-		msg := fmt.Sprintf("secrets manager service not found for account: %s", account)
+		msg := fmt.Sprintf("secretsmanager service not found for account: %s", account)
 		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
 		return
 	}

--- a/api/handlers_orchestration.go
+++ b/api/handlers_orchestration.go
@@ -31,13 +31,6 @@ func (s *server) ServiceOrchestrationCreateHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	sdService, ok := s.sdServices[account]
-	if !ok {
-		msg := fmt.Sprintf("service discovery service not found for account: %s", account)
-		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
-		return
-	}
-
 	iamService, ok := s.iamServices[account]
 	if !ok {
 		msg := fmt.Sprintf("iam service not found for account: %s", account)
@@ -45,10 +38,25 @@ func (s *server) ServiceOrchestrationCreateHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
+	sdService, ok := s.sdServices[account]
+	if !ok {
+		msg := fmt.Sprintf("service discovery service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	smService, ok := s.smServices[account]
+	if !ok {
+		msg := fmt.Sprintf("secrets manager service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
 	orchestrator := orchestration.Orchestrator{
-		ECS:              ecsService.Service,
+		ECS:              ecsService,
 		IAM:              iamService,
-		ServiceDiscovery: sdService.Service,
+		ServiceDiscovery: sdService,
+		SecretsManager:   smService,
 		Token:            uuid.NewV4().String(),
 	}
 
@@ -125,9 +133,17 @@ func (s *server) ServiceOrchestrationDeleteHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
+	sm, ok := s.smServices[account]
+	if !ok {
+		msg := fmt.Sprintf("secretsmanager service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
 	orchestrator := orchestration.Orchestrator{
-		ECS:              ecsService.Service,
-		ServiceDiscovery: sd.Service,
+		ECS:              ecsService,
+		ServiceDiscovery: sd,
+		SecretsManager:   sm,
 		Token:            uuid.NewV4().String(),
 	}
 

--- a/ecs/ecs_test.go
+++ b/ecs/ecs_test.go
@@ -5,7 +5,22 @@ import (
 	"testing"
 
 	"github.com/YaleSpinup/ecs-api/common"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
+
+// mockECSClient is a fake ecs client
+type mockECSClient struct {
+	ecsiface.ECSAPI
+	t   *testing.T
+	err error
+}
+
+func newmockECSClient(t *testing.T, err error) ecsiface.ECSAPI {
+	return &mockECSClient{
+		t:   t,
+		err: err,
+	}
+}
 
 func TestNewSession(t *testing.T) {
 	e := NewSession(common.Account{})

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/YaleSpinup/ecs-api
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.25.16
+	github.com/aws/aws-sdk-go v1.25.43
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
@@ -11,7 +12,8 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
+	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2
-	golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2 // indirect
+	golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,16 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.25.16 h1:k7Fy6T/uNuLX6zuayU/TJoP7yMgGcJSkZpF7QVjwYpA=
 github.com/aws/aws-sdk-go v1.25.16/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.43 h1:R5YqHQFIulYVfgRySz9hvBRTWBjudISa+r0C8XQ1ufg=
+github.com/aws/aws-sdk-go v1.25.43/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -25,6 +29,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
@@ -68,6 +73,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
+github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
+github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -83,6 +90,7 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -91,6 +99,8 @@ golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/nt
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2 h1:nq114VpM8lsSlP+lyUbANecYHYiFcSNFtqcBlxRV+gA=
 golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d h1:kCXqdOO2GMlu0vCsEMBXwj/b0E9wyFpNPBpuv/go/F8=
+golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/orchestration/cluster.go
+++ b/orchestration/cluster.go
@@ -1,0 +1,144 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// processCluster processes the cluster portion of the input.  If the cluster is defined on ths service object
+// it will be used, otherwise if the ClusterName is given, it will be created.  If neither is provided, an error
+// will be returned.
+func (o *Orchestrator) processCluster(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.Cluster, error) {
+	client := o.ECS.Service
+	if input.Service.Cluster != nil {
+		log.Infof("Using provided cluster name (input.Service.Cluster) %s", aws.StringValue(input.Service.Cluster))
+
+		cluster, err := getCluster(ctx, client, input.Service.Cluster)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debugf("Got cluster %+v", cluster)
+		return cluster, nil
+	} else if input.Cluster != nil {
+		log.Infof("Creating cluster %s", aws.StringValue(input.Cluster.ClusterName))
+
+		newTags := []*ecs.Tag{
+			&ecs.Tag{
+				Key:   aws.String("spinup:org"),
+				Value: aws.String(Org),
+			},
+		}
+
+		for _, t := range input.Cluster.Tags {
+			if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
+				newTags = append(newTags, t)
+			}
+		}
+		input.Cluster.Tags = newTags
+
+		cluster, err := createCluster(ctx, client, input.Cluster)
+		if err != nil {
+			return nil, err
+		}
+		log.Debugf("Created cluster %+v", cluster)
+		input.Service.Cluster = cluster.ClusterName
+		return cluster, nil
+	}
+	return nil, errors.New("A new or existing cluster is required")
+}
+
+// createCluster creates a cluster with context and name
+func createCluster(ctx context.Context, client ecsiface.ECSAPI, cluster *ecs.CreateClusterInput) (*ecs.Cluster, error) {
+	output, err := client.CreateClusterWithContext(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	return output.Cluster, err
+}
+
+// getCluster gets the details of a cluster with context by the cluster name
+func getCluster(ctx context.Context, client ecsiface.ECSAPI, name *string) (*ecs.Cluster, error) {
+	output, err := client.DescribeClustersWithContext(ctx, &ecs.DescribeClustersInput{
+		Clusters: []*string{name},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Failures) > 0 {
+		log.Warnf("describe clusters %s returned failures %+v", aws.StringValue(name), output.Failures)
+	}
+
+	if len(output.Clusters) == 0 {
+		msg := fmt.Sprintf("cluster %s not found", aws.StringValue(name))
+		return nil, errors.New(msg)
+	} else if len(output.Clusters) > 1 {
+		return nil, errors.New("unexpected number of clusters returned")
+	}
+
+	return output.Clusters[0], err
+}
+
+// deleteCluster deletes a(n empty) cluster
+func deleteCluster(ctx context.Context, client ecsiface.ECSAPI, name *string) error {
+	_, err := client.DeleteClusterWithContext(ctx, &ecs.DeleteClusterInput{Cluster: name})
+	if err != nil {
+		log.Errorf("error deleting cluster %s: %s", aws.StringValue(name), err)
+		return err
+	}
+	log.Infof("successfully deleted cluster %s", aws.StringValue(name))
+	return nil
+}
+
+// deleteClusterWithRetry continues to retry deleting a cluster until the context is cancelled or it succeeds
+func deleteClusterWithRetry(ctx context.Context, client ecsiface.ECSAPI, arn *string) chan string {
+	cluChan := make(chan string, 1)
+	go func() {
+		t := 1 * time.Second
+		for {
+			if ctx.Err() != nil {
+				log.Debug("cluster delete context is cancelled")
+				return
+			}
+
+			cluster, err := getCluster(ctx, client, arn)
+			if err != nil {
+				log.Errorf("error finding cluster to delete %s: %s", aws.StringValue(arn), err)
+				cluChan <- "unknown"
+				return
+			}
+			log.Debugf("found cluster %+v", cluster)
+
+			t *= 2
+			c := aws.Int64Value(cluster.RegisteredContainerInstancesCount)
+			if c > 0 {
+				log.Infof("found cluster %s, but registered instance count is > 0 (%d)", aws.StringValue(cluster.ClusterName), c)
+				time.Sleep(t)
+				continue
+			} else {
+				log.Infof("found cluster %s with registered instance count of 0, attempting to delete", aws.StringValue(cluster.ClusterName))
+				err := deleteCluster(ctx, client, arn)
+				if err != nil {
+					log.Errorf("error removing cluster %s: %s", aws.StringValue(arn), err)
+					time.Sleep(t)
+					continue
+				}
+			}
+
+			cluChan <- "success"
+			return
+		}
+	}()
+
+	return cluChan
+}

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -1,0 +1,79 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+func (m *mockECSClient) CreateClusterWithContext(ctx aws.Context, input *ecs.CreateClusterInput, opts ...request.Option) (*ecs.CreateClusterOutput, error) {
+	if aws.StringValue(input.ClusterName) == "goodclu" {
+		return &ecs.CreateClusterOutput{
+			Cluster: goodClu,
+		}, nil
+	}
+	return nil, errors.New("Failed to create mock cluster")
+}
+
+func (m *mockECSClient) DescribeClustersWithContext(ctx aws.Context, input *ecs.DescribeClustersInput, opts ...request.Option) (*ecs.DescribeClustersOutput, error) {
+	if len(input.Clusters) == 1 {
+		if aws.StringValue(input.Clusters[0]) == "goodclu" {
+			return &ecs.DescribeClustersOutput{
+				Clusters: []*ecs.Cluster{goodClu},
+			}, nil
+		}
+		msg := fmt.Sprintf("Failed to get mock cluster %s", aws.StringValue(input.Clusters[0]))
+		return nil, errors.New(msg)
+	} else if len(input.Clusters) > 1 {
+		return &ecs.DescribeClustersOutput{
+			Clusters: []*ecs.Cluster{
+				goodClu,
+				&ecs.Cluster{ClusterName: aws.String("fooclu")},
+				&ecs.Cluster{ClusterName: aws.String("barclu")},
+			},
+		}, nil
+	}
+	return nil, errors.New("Failed to describe mock clusters")
+}
+
+func TestCreateCluster(t *testing.T) {
+	client := &mockECSClient{}
+	cluster, err := createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("goodclu")})
+	if err != nil {
+		t.Fatal("expected no error from create cluster, got", err)
+	}
+	t.Log("got cluster response for good cluster", cluster)
+	if !reflect.DeepEqual(goodClu, cluster) {
+		t.Fatalf("Expected %+v\nGot %+v", goodClu, cluster)
+	}
+
+	cluster, err = createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("badclu")})
+	if err == nil {
+		t.Fatal("expected error from create cluster, got", err, cluster)
+	}
+	t.Log("got error response for bad cluster", err)
+}
+
+func TestGetCluster(t *testing.T) {
+	client := &mockECSClient{}
+	cluster, err := getCluster(context.TODO(), client, aws.String("goodclu"))
+	if err != nil {
+		t.Fatal("expected no error from get cluster, got", err)
+	}
+	t.Log("got cluster response for good cluster", cluster)
+	if !reflect.DeepEqual(goodClu, cluster) {
+		t.Fatalf("Expected %+v\nGot %+v", goodClu, cluster)
+	}
+
+	cluster, err = createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("badclu")})
+	if err == nil {
+		t.Fatal("expected error from get cluster, got", err, cluster)
+	}
+	t.Log("got expected error response for bad cluster", err)
+}

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -5,55 +5,15 @@ package orchestration
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/YaleSpinup/ecs-api/iam"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/aws/aws-sdk-go/service/servicediscovery/servicediscoveryiface"
 	log "github.com/sirupsen/logrus"
 )
-
-var (
-	// DefaultCompatabilities sets the default task definition compatabilities to
-	// Fargate.  By default, we won't support standard ECS.
-	// https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html
-	DefaultCompatabilities = []*string{
-		aws.String("FARGATE"),
-	}
-	// DefaultNetworkMode sets the default networking more for task definitions created
-	// by the api.  Currently, Fargate only supports vpc networking.
-	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
-	DefaultNetworkMode = aws.String("awsvpc")
-	// DefaultLaunchType sets the default launch type to Fargate
-	DefaultLaunchType = aws.String("FARGATE")
-	// DefaultPublic disables the setting of public IPs on ENIs by default
-	DefaultPublic = aws.String("DISABLED")
-	// DefaultSubnets sets a list of default subnets to attach ENIs
-	DefaultSubnets = []*string{}
-	// DefaultSecurityGroups sets a list of default sgs to attach to ENIs
-	DefaultSecurityGroups = []*string{}
-	// Org is the organization where this orchestration runs
-	Org = ""
-)
-
-// Orchestrator holds the service discovery client, iam client, ecs client, input, and output
-type Orchestrator struct {
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#ECS
-	ECS *ecs.ECS
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM
-	IAM iam.IAM
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/servicediscovery/#ServiceDiscovery
-	ServiceDiscovery *servicediscovery.ServiceDiscovery
-	// Token is a uniqueness token for calls to AWS
-	Token string
-}
 
 // ServiceOrchestrationInput encapsulates a single request for a service
 type ServiceOrchestrationInput struct {
@@ -61,6 +21,9 @@ type ServiceOrchestrationInput struct {
 	Cluster *ecs.CreateClusterInput
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#RegisterTaskDefinitionInput
 	TaskDefinition *ecs.RegisterTaskDefinitionInput
+	// map of container definition names to private repository credentials
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#CreateSecretInput
+	Credentials map[string]*secretsmanager.CreateSecretInput
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#CreateServiceInput
 	Service *ecs.CreateServiceInput
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/servicediscovery/#CreateServiceInput
@@ -100,6 +63,12 @@ func (o *Orchestrator) CreateService(ctx context.Context, input *ServiceOrchestr
 	}
 	output.Cluster = cluster
 
+	creds, err := o.processRepositoryCredentials(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("%+v", creds)
+
 	td, err := o.processTaskDefinition(ctx, input)
 	if err != nil {
 		return nil, err
@@ -124,445 +93,79 @@ func (o *Orchestrator) CreateService(ctx context.Context, input *ServiceOrchestr
 // DeleteService takes a service orchestrator, service name and a cluster to delete and removes
 // the service and the service registry
 func (o *Orchestrator) DeleteService(ctx context.Context, input *ServiceDeleteInput) (*ServiceOrchestrationOutput, error) {
-	service, err := getService(ctx, o.ECS, input.Cluster, input.Service)
+	service, err := getService(ctx, o.ECS.Service, input.Cluster, input.Service)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infof("removing service\n%+v", service)
-	err = deleteService(ctx, o.ECS, input)
+	log.Debugf("processing delete of service %+v", service)
+
+	taskDefinition, err := getTaskDefinition(ctx, o.ECS.Service, service.TaskDefinition)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("removing service '%s'", aws.StringValue(service.ServiceArn))
+
+	err = deleteService(ctx, o.ECS.Service, input)
 	if err != nil {
 		log.Errorf("error deleting service %s", err)
 		return nil, err
 	}
 
 	// recursively remove the service registry and the cluster if it's empty
+	// TODO: this should return a 202, not a 200
 	if input.Recursive {
-		if len(service.ServiceRegistries) > 0 {
-			for _, r := range service.ServiceRegistries {
-				srCtx, srCancel := context.WithTimeout(ctx, 10*time.Second)
-				defer srCancel()
+		log.Infof("removing '%s' dependencies recursively, asynchronously", aws.StringValue(service.ServiceArn))
+		go func() {
+			cleanupCtx := context.Background()
 
-				srChan := deleteServiceRegistryWithRetry(srCtx, o.ServiceDiscovery, r.RegistryArn)
-
-				// wait for a done context
-				select {
-				case <-srCtx.Done():
-					log.Errorf("timeout waiting for successful service registry %s deletion", aws.StringValue(r.RegistryArn))
-				case <-srChan:
-					log.Infof("successfully deleted service registry %s", aws.StringValue(r.RegistryArn))
+			// TODO: if we want to share repository credentials, we need to look for multiple
+			// container definitions using the same credentials.
+			for _, cd := range taskDefinition.ContainerDefinitions {
+				log.Debugf("cleaning '%s' container definition '%s' components", aws.StringValue(service.ServiceArn), aws.StringValue(cd.Name))
+				if cd.RepositoryCredentials != nil && aws.StringValue(cd.RepositoryCredentials.CredentialsParameter) != "" {
+					credsArn := aws.StringValue(cd.RepositoryCredentials.CredentialsParameter)
+					_, err = o.SecretsManager.DeleteSecret(cleanupCtx, credsArn, 0)
+					if err != nil {
+						log.Errorf("failed to delete secretsmanager secret '%s' for %s", credsArn, aws.StringValue(service.ServiceArn))
+					} else {
+						log.Infof("successfully deleted secretsmanager secret '%s'", credsArn)
+					}
 				}
 			}
-		}
 
-		cluCtx, cluCancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cluCancel()
+			cluCtx, cluCancel := context.WithTimeout(cleanupCtx, 120*time.Second)
+			defer cluCancel()
 
-		cluChan := deleteClusterWithRetry(cluCtx, o.ECS, service.ClusterArn)
+			cluChan := deleteClusterWithRetry(cluCtx, o.ECS.Service, service.ClusterArn)
 
-		// wait for a done context
-		select {
-		case <-cluCtx.Done():
-			log.Errorf("timeout waiting for successful cluster %s deletion", aws.StringValue(service.ClusterArn))
-		case <-cluChan:
-			log.Infof("successfully deleted cluster %s", aws.StringValue(service.ClusterArn))
-		}
+			// wait for a done context
+			select {
+			case <-cluCtx.Done():
+				log.Errorf("timeout waiting for successful cluster %s deletion", aws.StringValue(service.ClusterArn))
+			case <-cluChan:
+				log.Infof("successfully deleted cluster %s", aws.StringValue(service.ClusterArn))
+			}
 
+			if len(service.ServiceRegistries) > 0 {
+				for _, r := range service.ServiceRegistries {
+					srCtx, srCancel := context.WithTimeout(cleanupCtx, 120*time.Second)
+					defer srCancel()
+
+					srChan := deleteServiceRegistryWithRetry(srCtx, o.ServiceDiscovery.Service, r.RegistryArn)
+
+					// wait for a done context
+					select {
+					case <-srCtx.Done():
+						log.Errorf("timeout waiting for successful service registry %s deletion", aws.StringValue(r.RegistryArn))
+					case <-srChan:
+						log.Infof("successfully deleted service registry %s", aws.StringValue(r.RegistryArn))
+					}
+				}
+			}
+		}()
 	}
 
 	return &ServiceOrchestrationOutput{Service: service}, nil
-}
-
-// processCluster processes the cluster portion of the input.  If the cluster is defined on ths service object
-// it will be used, otherwise if the ClusterName is given, it will be created.  If neither is provided, an error
-// will be returned.
-func (o *Orchestrator) processCluster(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.Cluster, error) {
-	client := o.ECS
-	if input.Service.Cluster != nil {
-		log.Infof("Using provided cluster name (input.Service.Cluster) %s", aws.StringValue(input.Service.Cluster))
-
-		cluster, err := getCluster(ctx, client, input.Service.Cluster)
-		if err != nil {
-			return nil, err
-		}
-
-		log.Debugf("Got cluster %+v", cluster)
-		return cluster, nil
-	} else if input.Cluster != nil {
-		log.Infof("Creating cluster %s", aws.StringValue(input.Cluster.ClusterName))
-
-		newTags := []*ecs.Tag{
-			&ecs.Tag{
-				Key:   aws.String("spinup:org"),
-				Value: aws.String(Org),
-			},
-		}
-
-		for _, t := range input.Cluster.Tags {
-			if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
-				newTags = append(newTags, t)
-			}
-		}
-		input.Cluster.Tags = newTags
-
-		cluster, err := createCluster(ctx, client, input.Cluster)
-		if err != nil {
-			return nil, err
-		}
-		log.Debugf("Created cluster %+v", cluster)
-		input.Service.Cluster = cluster.ClusterName
-		return cluster, nil
-	}
-	return nil, errors.New("A new or existing cluster is required")
-}
-
-// createCluster creates a cluster with context and name
-func createCluster(ctx context.Context, client ecsiface.ECSAPI, cluster *ecs.CreateClusterInput) (*ecs.Cluster, error) {
-	output, err := client.CreateClusterWithContext(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-	return output.Cluster, err
-}
-
-// getCluster gets the details of a cluster with context by the cluster name
-func getCluster(ctx context.Context, client ecsiface.ECSAPI, name *string) (*ecs.Cluster, error) {
-	output, err := client.DescribeClustersWithContext(ctx, &ecs.DescribeClustersInput{
-		Clusters: []*string{name},
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(output.Failures) > 0 {
-		log.Warnf("describe clusters %s returned failures %+v", aws.StringValue(name), output.Failures)
-	}
-
-	if len(output.Clusters) == 0 {
-		msg := fmt.Sprintf("cluster %s not found", aws.StringValue(name))
-		return nil, errors.New(msg)
-	} else if len(output.Clusters) > 1 {
-		return nil, errors.New("unexpected number of clusters returned")
-	}
-
-	return output.Clusters[0], err
-}
-
-// deleteCluster deletes a(n empty) cluster
-func deleteCluster(ctx context.Context, client ecsiface.ECSAPI, name *string) error {
-	_, err := client.DeleteClusterWithContext(ctx, &ecs.DeleteClusterInput{Cluster: name})
-	if err != nil {
-		log.Errorf("error deleting cluster %s: %s", aws.StringValue(name), err)
-		return err
-	}
-	log.Infof("successfully deleted cluster %s", aws.StringValue(name))
-	return nil
-}
-
-// deleteClusterWithRetry continues to retry deleting a cluster until the context is cancelled or it succeeds
-func deleteClusterWithRetry(ctx context.Context, client ecsiface.ECSAPI, arn *string) chan string {
-	cluChan := make(chan string, 1)
-	go func() {
-		t := 1 * time.Second
-		for {
-			if ctx.Err() != nil {
-				log.Debug("cluster delete context is cancelled")
-				return
-			}
-
-			cluster, err := getCluster(ctx, client, arn)
-			if err != nil {
-				log.Errorf("error finding cluster to delete %s: %s", aws.StringValue(arn), err)
-				cluChan <- "unknown"
-				return
-			}
-			log.Debugf("found cluster %+v", cluster)
-
-			t *= 2
-			c := aws.Int64Value(cluster.RegisteredContainerInstancesCount)
-			if c > 0 {
-				log.Infof("found cluster %s, but registered instance count is > 0 (%d)", aws.StringValue(cluster.ClusterName), c)
-				time.Sleep(t)
-				continue
-			} else {
-				log.Infof("found cluster %s with registered instance count of 0, attempting to delete", aws.StringValue(cluster.ClusterName))
-				err := deleteCluster(ctx, client, arn)
-				if err != nil {
-					log.Errorf("error removing cluster %s: %s", aws.StringValue(arn), err)
-					time.Sleep(t)
-					continue
-				}
-			}
-
-			cluChan <- "success"
-			return
-		}
-	}()
-
-	return cluChan
-}
-
-// processTaskDefinition processes the task definition portion of the input.  If the task definition is provided with
-// the service object, it is used.  Otherwise, if the task definition is defined as input, it will be created.  If neither
-// is true, an error is returned.
-func (o *Orchestrator) processTaskDefinition(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.TaskDefinition, error) {
-	client := o.ECS
-
-	if input.Service.TaskDefinition != nil {
-		log.Infof("using provided task definition %s", aws.StringValue(input.Service.TaskDefinition))
-		taskDefinition, err := getTaskDefinition(ctx, client, input.Service.TaskDefinition)
-		if err != nil {
-			return nil, err
-		}
-		return taskDefinition, nil
-	} else if input.TaskDefinition != nil {
-
-		newTags := []*ecs.Tag{
-			&ecs.Tag{
-				Key:   aws.String("spinup:org"),
-				Value: aws.String(Org),
-			},
-		}
-
-		for _, t := range input.TaskDefinition.Tags {
-			if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
-				newTags = append(newTags, t)
-			}
-		}
-		input.TaskDefinition.Tags = newTags
-
-		log.Infof("creating task definition %+v", input.TaskDefinition)
-
-		if input.TaskDefinition.ExecutionRoleArn == nil {
-			path := fmt.Sprintf("%s/%s", Org, *input.Cluster.ClusterName)
-			roleARN, err := o.IAM.DefaultTaskExecutionRole(ctx, path)
-			if err != nil {
-				return nil, err
-			}
-
-			input.TaskDefinition.ExecutionRoleArn = &roleARN
-		}
-
-		taskDefinition, err := createTaskDefinition(ctx, client, input.TaskDefinition)
-		if err != nil {
-			return nil, err
-		}
-
-		td := fmt.Sprintf("%s:%d", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
-		input.Service.TaskDefinition = aws.String(td)
-		return taskDefinition, nil
-	}
-
-	return nil, errors.New("taskDefinition or service task definition name is required")
-}
-
-// createTaskDefinition creates a task definition with context and input
-func createTaskDefinition(ctx context.Context, client ecsiface.ECSAPI, input *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error) {
-	if len(input.RequiresCompatibilities) == 0 {
-		input.RequiresCompatibilities = DefaultCompatabilities
-	}
-
-	if input.NetworkMode == nil {
-		input.NetworkMode = DefaultNetworkMode
-	}
-
-	output, err := client.RegisterTaskDefinitionWithContext(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-
-	return output.TaskDefinition, err
-}
-
-// getTaskDefinition gets a task definition with context by name
-func getTaskDefinition(ctx context.Context, client ecsiface.ECSAPI, name *string) (*ecs.TaskDefinition, error) {
-	output, err := client.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
-		TaskDefinition: name,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return output.TaskDefinition, err
-}
-
-// processServiceRegistry processes the service registry portion of the input.  If a service registry is provided as
-// part of the service object, it will be used.  Alternatively, if a service registry definition is provided as input it
-// will be created.  Otherwise the service will not be registered with service discovery.
-func (o *Orchestrator) processServiceRegistry(ctx context.Context, input *ServiceOrchestrationInput) (*servicediscovery.Service, error) {
-	client := o.ServiceDiscovery
-	if len(input.Service.ServiceRegistries) > 0 {
-		log.Infof("using provided service registry %s", aws.StringValue(input.Service.ServiceRegistries[0].RegistryArn))
-		arn, err := arn.Parse(aws.StringValue(input.Service.ServiceRegistries[0].RegistryArn))
-		if err != nil {
-			return nil, err
-		}
-
-		resource := strings.SplitN(arn.Resource, "/", 2)
-		log.Debugf("split resource into type: %s and id: %s", resource[0], resource[1])
-
-		sd, err := getServiceDiscoveryService(ctx, client, aws.String(resource[1]))
-		if err != nil {
-			return nil, err
-		}
-
-		return sd, nil
-	} else if input.ServiceRegistry != nil {
-		log.Infof("creating service registry %+v", input.ServiceRegistry)
-		sd, err := createServiceDiscoveryService(ctx, client, input.ServiceRegistry)
-		if err != nil {
-			return nil, err
-		}
-
-		input.Service.ServiceRegistries = append(input.Service.ServiceRegistries, &ecs.ServiceRegistry{
-			RegistryArn: sd.Arn,
-		})
-
-		return sd, nil
-	}
-
-	log.Warn("service discovery registry was not provided, not registering")
-	return nil, nil
-}
-
-// getServiceDiscoveryService gets the details of a service discovery service
-func getServiceDiscoveryService(ctx context.Context, client servicediscoveryiface.ServiceDiscoveryAPI, id *string) (*servicediscovery.Service, error) {
-	output, err := client.GetServiceWithContext(ctx, &servicediscovery.GetServiceInput{Id: id})
-	if err != nil {
-		return nil, err
-	}
-	return output.Service, err
-}
-
-// createServiceDiscoveryService creates a service discovery service
-func createServiceDiscoveryService(ctx context.Context, client servicediscoveryiface.ServiceDiscoveryAPI, input *servicediscovery.CreateServiceInput) (*servicediscovery.Service, error) {
-	input.SetHealthCheckCustomConfig(&servicediscovery.HealthCheckCustomConfig{FailureThreshold: aws.Int64(1)})
-	output, err := client.CreateServiceWithContext(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	return output.Service, err
-}
-
-// deleteServiceRegistry removes a service discovery service by it's ID
-func deleteServiceRegistry(ctx context.Context, client *servicediscovery.ServiceDiscovery, serviceArn *string) error {
-	// parse the ARN into it's component parts and split the resource/resource-id
-	a, err := arn.Parse(aws.StringValue(serviceArn))
-	if err != nil {
-		return err
-	}
-
-	resource := strings.SplitN(a.Resource, "/", 2)
-	output, err := client.DeleteServiceWithContext(ctx, &servicediscovery.DeleteServiceInput{
-		Id: aws.String(resource[1]),
-	})
-
-	if err != nil {
-		return err
-	}
-
-	log.Debugf("output from service discovery service delete:\n%+v", output)
-	return nil
-}
-
-// deleteServiceRegistryWithRetry continues to retry deleting a service registration until the context is cancelled or it succeeds
-func deleteServiceRegistryWithRetry(ctx context.Context, client *servicediscovery.ServiceDiscovery, serviceArn *string) chan string {
-	srChan := make(chan string, 1)
-	go func() {
-		t := 1 * time.Second
-		for {
-			if ctx.Err() != nil {
-				log.Debug("service registration delete context is cancelled")
-				return
-			}
-
-			t *= 2
-			log.Debugf("attempting to remove service registry: %s", aws.StringValue(serviceArn))
-			err := deleteServiceRegistry(ctx, client, serviceArn)
-			if err != nil {
-				log.Warnf("failed removing service registry %s: %s", aws.StringValue(serviceArn), err)
-				time.Sleep(t)
-				continue
-			}
-
-			srChan <- "success"
-			return
-		}
-	}()
-	return srChan
-}
-
-// processService processes the service input.  It normalizes inputs and creates the ECS service.
-func (o *Orchestrator) processService(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.Service, error) {
-	client := o.ECS
-	if input.Service.ClientToken == nil {
-		input.Service.ClientToken = aws.String(o.Token)
-	}
-
-	if input.Service.NetworkConfiguration == nil {
-		input.Service.NetworkConfiguration = &ecs.NetworkConfiguration{
-			AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
-				AssignPublicIp: DefaultPublic,
-				SecurityGroups: DefaultSecurityGroups,
-				Subnets:        DefaultSubnets,
-			},
-		}
-	}
-
-	newTags := []*ecs.Tag{
-		&ecs.Tag{
-			Key:   aws.String("spinup:org"),
-			Value: aws.String(Org),
-		},
-	}
-
-	for _, t := range input.Service.Tags {
-		if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
-			newTags = append(newTags, t)
-		}
-	}
-	input.Service.Tags = newTags
-
-	if input.Service.LaunchType == nil {
-		input.Service.LaunchType = DefaultLaunchType
-	}
-	log.Debugf("processing service with input:\n%+v", input.Service)
-	output, err := client.CreateServiceWithContext(ctx, input.Service)
-	if err != nil {
-		return nil, err
-	}
-
-	return output.Service, nil
-}
-
-// getService describes an ECS service in a cluster by the service name
-func getService(ctx context.Context, client ecsiface.ECSAPI, cluster, service *string) (*ecs.Service, error) {
-	output, err := client.DescribeServicesWithContext(ctx, &ecs.DescribeServicesInput{
-		Cluster:  cluster,
-		Services: []*string{service},
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(output.Services) != 1 {
-		return nil, errors.New("unexpected service length in describe services")
-	}
-
-	return output.Services[0], nil
-}
-
-// deleteService removes an ECS service in a cluster by the service name (forcefully)
-func deleteService(ctx context.Context, client ecsiface.ECSAPI, input *ServiceDeleteInput) error {
-	output, err := client.DeleteServiceWithContext(ctx, &ecs.DeleteServiceInput{
-		Cluster: input.Cluster,
-		Service: input.Service,
-		Force:   aws.Bool(true),
-	})
-
-	log.Debugf("output from delete service:\n%+v", output)
-	return err
 }

--- a/orchestration/orchestration_test.go
+++ b/orchestration/orchestration_test.go
@@ -1,16 +1,11 @@
 package orchestration
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"reflect"
-	"testing"
-
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/aws-sdk-go/service/servicediscovery/servicediscoveryiface"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
@@ -20,8 +15,16 @@ type mockECSClient struct {
 	ecsiface.ECSAPI
 }
 
+type mockIAMClient struct {
+	iamiface.IAMAPI
+}
+
 type mockSDClient struct {
 	servicediscoveryiface.ServiceDiscoveryAPI
+}
+
+type mockSMClient struct {
+	secretsmanageriface.SecretsManagerAPI
 }
 
 var (
@@ -66,212 +69,3 @@ var (
 		},
 	}
 )
-
-func (m *mockECSClient) CreateClusterWithContext(ctx aws.Context, input *ecs.CreateClusterInput, opts ...request.Option) (*ecs.CreateClusterOutput, error) {
-	if aws.StringValue(input.ClusterName) == "goodclu" {
-		return &ecs.CreateClusterOutput{
-			Cluster: goodClu,
-		}, nil
-	}
-	return nil, errors.New("Failed to create mock cluster")
-}
-
-func (m *mockECSClient) DescribeClustersWithContext(ctx aws.Context, input *ecs.DescribeClustersInput, opts ...request.Option) (*ecs.DescribeClustersOutput, error) {
-	if len(input.Clusters) == 1 {
-		if aws.StringValue(input.Clusters[0]) == "goodclu" {
-			return &ecs.DescribeClustersOutput{
-				Clusters: []*ecs.Cluster{goodClu},
-			}, nil
-		}
-		msg := fmt.Sprintf("Failed to get mock cluster %s", aws.StringValue(input.Clusters[0]))
-		return nil, errors.New(msg)
-	} else if len(input.Clusters) > 1 {
-		return &ecs.DescribeClustersOutput{
-			Clusters: []*ecs.Cluster{
-				goodClu,
-				&ecs.Cluster{ClusterName: aws.String("fooclu")},
-				&ecs.Cluster{ClusterName: aws.String("barclu")},
-			},
-		}, nil
-	}
-	return nil, errors.New("Failed to describe mock clusters")
-}
-
-func TestCreateCluster(t *testing.T) {
-	client := &mockECSClient{}
-	cluster, err := createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("goodclu")})
-	if err != nil {
-		t.Fatal("expected no error from create cluster, got", err)
-	}
-	t.Log("got cluster response for good cluster", cluster)
-	if !reflect.DeepEqual(goodClu, cluster) {
-		t.Fatalf("Expected %+v\nGot %+v", goodClu, cluster)
-	}
-
-	cluster, err = createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("badclu")})
-	if err == nil {
-		t.Fatal("expected error from create cluster, got", err, cluster)
-	}
-	t.Log("got error response for bad cluster", err)
-}
-
-func TestGetCluster(t *testing.T) {
-	client := &mockECSClient{}
-	cluster, err := getCluster(context.TODO(), client, aws.String("goodclu"))
-	if err != nil {
-		t.Fatal("expected no error from get cluster, got", err)
-	}
-	t.Log("got cluster response for good cluster", cluster)
-	if !reflect.DeepEqual(goodClu, cluster) {
-		t.Fatalf("Expected %+v\nGot %+v", goodClu, cluster)
-	}
-
-	cluster, err = createCluster(context.TODO(), client, &ecs.CreateClusterInput{ClusterName: aws.String("badclu")})
-	if err == nil {
-		t.Fatal("expected error from get cluster, got", err, cluster)
-	}
-	t.Log("got expected error response for bad cluster", err)
-}
-
-func (m *mockECSClient) RegisterTaskDefinitionWithContext(ctx aws.Context, input *ecs.RegisterTaskDefinitionInput, opts ...request.Option) (*ecs.RegisterTaskDefinitionOutput, error) {
-	if aws.StringValue(input.Family) == "goodtd" {
-		goodTd.Compatibilities = input.RequiresCompatibilities
-		goodTd.NetworkMode = input.NetworkMode
-		return &ecs.RegisterTaskDefinitionOutput{
-			TaskDefinition: goodTd,
-		}, nil
-	}
-	return nil, errors.New("Failed to create mock task definition")
-}
-
-func (m *mockECSClient) DescribeTaskDefinitionWithContext(ctx aws.Context, input *ecs.DescribeTaskDefinitionInput, opts ...request.Option) (*ecs.DescribeTaskDefinitionOutput, error) {
-	if aws.StringValue(input.TaskDefinition) == "goodtd" {
-		return &ecs.DescribeTaskDefinitionOutput{
-			TaskDefinition: goodTd,
-		}, nil
-	}
-	msg := fmt.Sprintf("Failed to get mock task definition %s", aws.StringValue(input.TaskDefinition))
-	return nil, errors.New(msg)
-}
-
-func TestCreateTaskDefinition(t *testing.T) {
-	client := &mockECSClient{}
-
-	// test a boring task definition
-	td, err := createTaskDefinition(context.TODO(), client, &ecs.RegisterTaskDefinitionInput{Family: aws.String("goodtd")})
-	if err != nil {
-		t.Fatal("expected no error from create task definition, got:", err)
-	}
-	t.Log("got task definition response for good task definition", td)
-	if !reflect.DeepEqual(goodTd, td) {
-		t.Fatalf("Expected %+v\nGot %+v", goodTd, td)
-	}
-
-	// test an error task definition
-	td, err = createTaskDefinition(context.TODO(), client, &ecs.RegisterTaskDefinitionInput{})
-	if err == nil {
-		t.Fatal("expected error from create task definition, got", err, td)
-	}
-	t.Log("got expected error response for bad task definition", err)
-
-	// test a task definition with custom compatabilities
-	td, err = createTaskDefinition(context.TODO(), client, &ecs.RegisterTaskDefinitionInput{
-		Family:                  aws.String("goodtd"),
-		RequiresCompatibilities: aws.StringSlice([]string{"FOOBAR"}),
-	})
-	if err != nil {
-		t.Fatal("expected no error from create task definition with custom compatabilities, got:", err)
-	}
-	if !reflect.DeepEqual([]string{"FOOBAR"}, aws.StringValueSlice(td.Compatibilities)) {
-		t.Fatal("Expected compatabilitieis to be custom:", []string{"FOOBAR"}, "got:", aws.StringValueSlice(td.Compatibilities))
-	}
-	t.Log("got task definition response for good task definition with custom compatablilities", td)
-}
-
-func TestDescribeTaskDefinition(t *testing.T) {
-	client := &mockECSClient{}
-	td, err := getTaskDefinition(context.TODO(), client, aws.String("goodtd"))
-	if err != nil {
-		t.Fatal("expected no error from describe task definition, got:", err)
-	}
-	t.Log("got task definition response for good task definition", td)
-	if !reflect.DeepEqual(goodTd, td) {
-		t.Fatalf("Expected %+v\nGot %+v", goodTd, td)
-	}
-
-	// test an error task definition
-	td, err = getTaskDefinition(context.TODO(), client, aws.String("badtd"))
-	if err == nil {
-		t.Fatal("expected error from create task definition, got", err, td)
-	}
-	t.Log("got expected error response for bad task definition", err)
-}
-
-func (m *mockSDClient) CreateServiceWithContext(ctx aws.Context, input *servicediscovery.CreateServiceInput, opts ...request.Option) (*servicediscovery.CreateServiceOutput, error) {
-	if aws.StringValue(input.Name) == "goodsd" {
-		return &servicediscovery.CreateServiceOutput{
-			Service: goodSd,
-		}, nil
-	}
-	msg := fmt.Sprintf("Failed to get mock service discovery service %s", aws.StringValue(input.Name))
-	return nil, errors.New(msg)
-}
-
-func (m *mockSDClient) GetServiceWithContext(ctx aws.Context, input *servicediscovery.GetServiceInput, opts ...request.Option) (*servicediscovery.GetServiceOutput, error) {
-	if aws.StringValue(input.Id) == "srv-goodsd" {
-		return &servicediscovery.GetServiceOutput{
-			Service: goodSd,
-		}, nil
-	}
-	msg := fmt.Sprintf("Failed to get mock service discovery service %s", aws.StringValue(input.Id))
-	return nil, errors.New(msg)
-}
-
-func TestCreateServiceDiscovery(t *testing.T) {
-	client := &mockSDClient{}
-	sd, err := createServiceDiscoveryService(context.TODO(), client, &servicediscovery.CreateServiceInput{
-		Name: aws.String("goodsd"),
-		DnsConfig: &servicediscovery.DnsConfig{
-			DnsRecords: []*servicediscovery.DnsRecord{
-				&servicediscovery.DnsRecord{
-					TTL:  aws.Int64(30),
-					Type: aws.String("A"),
-				},
-			},
-			NamespaceId: aws.String("ns-p5g6iyxdh5c5h3dr"),
-		},
-	})
-	if err != nil {
-		t.Fatal("expected no error from create service discovery service, got", err)
-	}
-	t.Log("Got service discovery create service output", sd)
-	if !reflect.DeepEqual(sd, goodSd) {
-		t.Fatalf("expected: %+v\nGot:%+v", goodSd, sd)
-	}
-
-	sd, err = createServiceDiscoveryService(context.TODO(), client, &servicediscovery.CreateServiceInput{
-		Name: aws.String("badsd"),
-	})
-	if err == nil {
-		t.Fatalf("expected error from bad create service discovery service, got %+v", sd)
-	}
-	t.Log("Got expected error from bad service discovery create service", err)
-}
-
-func TestGetServiceDiscovery(t *testing.T) {
-	client := &mockSDClient{}
-	sd, err := getServiceDiscoveryService(context.TODO(), client, aws.String("srv-goodsd"))
-	if err != nil {
-		t.Fatal("expected no error from get service discovery service, got", err)
-	}
-	t.Log("Got service discovery get service output", sd)
-	if !reflect.DeepEqual(sd, goodSd) {
-		t.Fatalf("expected: %+v\n Got: %+v", goodSd, sd)
-	}
-
-	sd, err = getServiceDiscoveryService(context.TODO(), client, aws.String("srv-badsd"))
-	if err == nil {
-		t.Fatalf("expected error from bad get service discovery service, got %+v", sd)
-	}
-	t.Log("Got expected error from bad service discovery service", err)
-}

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -1,0 +1,48 @@
+// Package orchestration brings together the other components of the API into a
+// single orchestration interface for creating and deleting ecs services
+package orchestration
+
+import (
+	"github.com/YaleSpinup/ecs-api/ecs"
+	"github.com/YaleSpinup/ecs-api/iam"
+	"github.com/YaleSpinup/ecs-api/secretsmanager"
+	"github.com/YaleSpinup/ecs-api/servicediscovery"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+var (
+	// DefaultCompatabilities sets the default task definition compatabilities to
+	// Fargate.  By default, we won't support standard ECS.
+	// https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html
+	DefaultCompatabilities = []*string{
+		aws.String("FARGATE"),
+	}
+	// DefaultNetworkMode sets the default networking more for task definitions created
+	// by the api.  Currently, Fargate only supports vpc networking.
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
+	DefaultNetworkMode = aws.String("awsvpc")
+	// DefaultLaunchType sets the default launch type to Fargate
+	DefaultLaunchType = aws.String("FARGATE")
+	// DefaultPublic disables the setting of public IPs on ENIs by default
+	DefaultPublic = aws.String("DISABLED")
+	// DefaultSubnets sets a list of default subnets to attach ENIs
+	DefaultSubnets = []*string{}
+	// DefaultSecurityGroups sets a list of default sgs to attach to ENIs
+	DefaultSecurityGroups = []*string{}
+	// Org is the organization where this orchestration runs
+	Org = ""
+)
+
+// Orchestrator holds the service discovery client, iam client, ecs client, secretsmanager client, input, and output
+type Orchestrator struct {
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#ECS
+	ECS ecs.ECS
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM
+	IAM iam.IAM
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#SecretsManager
+	SecretsManager secretsmanager.SecretsManager
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/servicediscovery/#ServiceDiscovery
+	ServiceDiscovery servicediscovery.ServiceDiscovery
+	// Token is a uniqueness token for calls to AWS
+	Token string
+}

--- a/orchestration/orchestrator_test.go
+++ b/orchestration/orchestrator_test.go
@@ -1,0 +1,1 @@
+package orchestration

--- a/orchestration/repositorycredentials.go
+++ b/orchestration/repositorycredentials.go
@@ -1,0 +1,63 @@
+package orchestration
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	log "github.com/sirupsen/logrus"
+)
+
+// processRepositoryCredentials processes the Credentials portion of the input.  If existing repository credentials are
+// provided with the task definition, they are used.  Otherwise, if the credentials are defined as input, they are created
+// in the secretsmanager service.  If neither is true, nil is returned.
+func (o *Orchestrator) processRepositoryCredentials(ctx context.Context, input *ServiceOrchestrationInput) (map[string]*secretsmanager.CreateSecretOutput, error) {
+	if len(input.Credentials) == 0 {
+		log.Debugf("no private repository credentials passed")
+		return nil, nil
+	}
+
+	client := o.SecretsManager
+	creds := make(map[string]*secretsmanager.CreateSecretOutput, len(input.Credentials))
+	for _, cd := range input.TaskDefinition.ContainerDefinitions {
+		name := aws.StringValue(cd.Name)
+		log.Debugf("processing container definition %s", name)
+		if cd.RepositoryCredentials != nil {
+			log.Infof("using respository credentials referenced in container definition %s: %s", name, cd.RepositoryCredentials.String())
+		} else if secret, ok := input.Credentials[name]; ok {
+			log.Infof("creating repository credentials secret for container definition: %s", name)
+
+			newTags := []*secretsmanager.Tag{
+				&secretsmanager.Tag{
+					Key:   aws.String("spinup:org"),
+					Value: aws.String(Org),
+				},
+			}
+
+			for _, t := range secret.Tags {
+				if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
+					newTags = append(newTags, t)
+				}
+			}
+			secret.Tags = newTags
+
+			out, err := client.CreateSecret(ctx, secret)
+			if err != nil {
+				return nil, err
+			}
+
+			log.Debugf("output: %+v", out)
+
+			log.Infof("setting repository credentials secret for container definition: %s to %s", name, aws.StringValue(out.ARN))
+			cd.SetRepositoryCredentials(&ecs.RepositoryCredentials{
+				CredentialsParameter: out.ARN,
+			})
+			creds[name] = out
+		} else {
+			log.Infof("assuming container definition %s references a public image, no credentials included", name)
+		}
+	}
+
+	return creds, nil
+}

--- a/orchestration/repositorycredentials_test.go
+++ b/orchestration/repositorycredentials_test.go
@@ -1,0 +1,9 @@
+package orchestration
+
+import (
+	"testing"
+)
+
+func TestProcessRepositoryCredentials(t *testing.T) {
+
+}

--- a/orchestration/service.go
+++ b/orchestration/service.go
@@ -1,0 +1,85 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// processService processes the service input.  It normalizes inputs and creates the ECS service.
+func (o *Orchestrator) processService(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.Service, error) {
+	client := o.ECS.Service
+	if input.Service.ClientToken == nil {
+		input.Service.ClientToken = aws.String(o.Token)
+	}
+
+	if input.Service.NetworkConfiguration == nil {
+		input.Service.NetworkConfiguration = &ecs.NetworkConfiguration{
+			AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+				AssignPublicIp: DefaultPublic,
+				SecurityGroups: DefaultSecurityGroups,
+				Subnets:        DefaultSubnets,
+			},
+		}
+	}
+
+	newTags := []*ecs.Tag{
+		&ecs.Tag{
+			Key:   aws.String("spinup:org"),
+			Value: aws.String(Org),
+		},
+	}
+
+	for _, t := range input.Service.Tags {
+		if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
+			newTags = append(newTags, t)
+		}
+	}
+	input.Service.Tags = newTags
+
+	if input.Service.LaunchType == nil {
+		input.Service.LaunchType = DefaultLaunchType
+	}
+	log.Debugf("processing service with input:\n%+v", input.Service)
+	output, err := client.CreateServiceWithContext(ctx, input.Service)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.Service, nil
+}
+
+// getService describes an ECS service in a cluster by the service name
+func getService(ctx context.Context, client ecsiface.ECSAPI, cluster, service *string) (*ecs.Service, error) {
+	output, err := client.DescribeServicesWithContext(ctx, &ecs.DescribeServicesInput{
+		Cluster:  cluster,
+		Services: []*string{service},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Services) != 1 {
+		return nil, errors.New("unexpected service length in describe services")
+	}
+
+	return output.Services[0], nil
+}
+
+// deleteService removes an ECS service in a cluster by the service name (forcefully)
+func deleteService(ctx context.Context, client ecsiface.ECSAPI, input *ServiceDeleteInput) error {
+	output, err := client.DeleteServiceWithContext(ctx, &ecs.DeleteServiceInput{
+		Cluster: input.Cluster,
+		Service: input.Service,
+		Force:   aws.Bool(true),
+	})
+
+	log.Debugf("output from delete service:\n%+v", output)
+	return err
+}

--- a/orchestration/service_test.go
+++ b/orchestration/service_test.go
@@ -1,0 +1,30 @@
+package orchestration
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+)
+
+func (m *mockSDClient) CreateServiceWithContext(ctx aws.Context, input *servicediscovery.CreateServiceInput, opts ...request.Option) (*servicediscovery.CreateServiceOutput, error) {
+	if aws.StringValue(input.Name) == "goodsd" {
+		return &servicediscovery.CreateServiceOutput{
+			Service: goodSd,
+		}, nil
+	}
+	msg := fmt.Sprintf("Failed to get mock service discovery service %s", aws.StringValue(input.Name))
+	return nil, errors.New(msg)
+}
+
+func (m *mockSDClient) GetServiceWithContext(ctx aws.Context, input *servicediscovery.GetServiceInput, opts ...request.Option) (*servicediscovery.GetServiceOutput, error) {
+	if aws.StringValue(input.Id) == "srv-goodsd" {
+		return &servicediscovery.GetServiceOutput{
+			Service: goodSd,
+		}, nil
+	}
+	msg := fmt.Sprintf("Failed to get mock service discovery service %s", aws.StringValue(input.Id))
+	return nil, errors.New(msg)
+}

--- a/orchestration/servicediscovery.go
+++ b/orchestration/servicediscovery.go
@@ -1,0 +1,121 @@
+package orchestration
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/aws/aws-sdk-go/service/servicediscovery/servicediscoveryiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// processServiceRegistry processes the service registry portion of the input.  If a service registry is provided as
+// part of the service object, it will be used.  Alternatively, if a service registry definition is provided as input it
+// will be created.  Otherwise the service will not be registered with service discovery.
+func (o *Orchestrator) processServiceRegistry(ctx context.Context, input *ServiceOrchestrationInput) (*servicediscovery.Service, error) {
+	client := o.ServiceDiscovery.Service
+	if len(input.Service.ServiceRegistries) > 0 {
+		log.Infof("using provided service registry %s", aws.StringValue(input.Service.ServiceRegistries[0].RegistryArn))
+		arn, err := arn.Parse(aws.StringValue(input.Service.ServiceRegistries[0].RegistryArn))
+		if err != nil {
+			return nil, err
+		}
+
+		resource := strings.SplitN(arn.Resource, "/", 2)
+		log.Debugf("split resource into type: %s and id: %s", resource[0], resource[1])
+
+		sd, err := getServiceDiscoveryService(ctx, client, aws.String(resource[1]))
+		if err != nil {
+			return nil, err
+		}
+
+		return sd, nil
+	} else if input.ServiceRegistry != nil {
+		log.Infof("creating service registry %+v", input.ServiceRegistry)
+		sd, err := createServiceDiscoveryService(ctx, client, input.ServiceRegistry)
+		if err != nil {
+			return nil, err
+		}
+
+		input.Service.ServiceRegistries = append(input.Service.ServiceRegistries, &ecs.ServiceRegistry{
+			RegistryArn: sd.Arn,
+		})
+
+		return sd, nil
+	}
+
+	log.Warn("service discovery registry was not provided, not registering")
+	return nil, nil
+}
+
+// getServiceDiscoveryService gets the details of a service discovery service
+func getServiceDiscoveryService(ctx context.Context, client servicediscoveryiface.ServiceDiscoveryAPI, id *string) (*servicediscovery.Service, error) {
+	output, err := client.GetServiceWithContext(ctx, &servicediscovery.GetServiceInput{Id: id})
+	if err != nil {
+		return nil, err
+	}
+	return output.Service, err
+}
+
+// createServiceDiscoveryService creates a service discovery service
+func createServiceDiscoveryService(ctx context.Context, client servicediscoveryiface.ServiceDiscoveryAPI, input *servicediscovery.CreateServiceInput) (*servicediscovery.Service, error) {
+	input.SetHealthCheckCustomConfig(&servicediscovery.HealthCheckCustomConfig{FailureThreshold: aws.Int64(1)})
+	output, err := client.CreateServiceWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return output.Service, err
+}
+
+// deleteServiceRegistry removes a service discovery service by it's ID
+func deleteServiceRegistry(ctx context.Context, client *servicediscovery.ServiceDiscovery, serviceArn *string) error {
+	// parse the ARN into it's component parts and split the resource/resource-id
+	a, err := arn.Parse(aws.StringValue(serviceArn))
+	if err != nil {
+		return err
+	}
+
+	resource := strings.SplitN(a.Resource, "/", 2)
+	output, err := client.DeleteServiceWithContext(ctx, &servicediscovery.DeleteServiceInput{
+		Id: aws.String(resource[1]),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("output from service discovery service delete:\n%+v", output)
+	return nil
+}
+
+// deleteServiceRegistryWithRetry continues to retry deleting a service registration until the context is cancelled or it succeeds
+func deleteServiceRegistryWithRetry(ctx context.Context, client *servicediscovery.ServiceDiscovery, serviceArn *string) chan string {
+	srChan := make(chan string, 1)
+	go func() {
+		t := 1 * time.Second
+		for {
+			if ctx.Err() != nil {
+				log.Debug("service registration delete context is cancelled")
+				return
+			}
+
+			t *= 2
+			log.Debugf("attempting to remove service registry: %s", aws.StringValue(serviceArn))
+			err := deleteServiceRegistry(ctx, client, serviceArn)
+			if err != nil {
+				log.Warnf("failed removing service registry %s: %s", aws.StringValue(serviceArn), err)
+				time.Sleep(t)
+				continue
+			}
+
+			srChan <- "success"
+			return
+		}
+	}()
+	return srChan
+}

--- a/orchestration/servicediscovery_test.go
+++ b/orchestration/servicediscovery_test.go
@@ -1,0 +1,59 @@
+package orchestration
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+)
+
+func TestCreateServiceDiscovery(t *testing.T) {
+	client := &mockSDClient{}
+	sd, err := createServiceDiscoveryService(context.TODO(), client, &servicediscovery.CreateServiceInput{
+		Name: aws.String("goodsd"),
+		DnsConfig: &servicediscovery.DnsConfig{
+			DnsRecords: []*servicediscovery.DnsRecord{
+				&servicediscovery.DnsRecord{
+					TTL:  aws.Int64(30),
+					Type: aws.String("A"),
+				},
+			},
+			NamespaceId: aws.String("ns-p5g6iyxdh5c5h3dr"),
+		},
+	})
+	if err != nil {
+		t.Fatal("expected no error from create service discovery service, got", err)
+	}
+	t.Log("Got service discovery create service output", sd)
+	if !reflect.DeepEqual(sd, goodSd) {
+		t.Fatalf("expected: %+v\nGot:%+v", goodSd, sd)
+	}
+
+	sd, err = createServiceDiscoveryService(context.TODO(), client, &servicediscovery.CreateServiceInput{
+		Name: aws.String("badsd"),
+	})
+	if err == nil {
+		t.Fatalf("expected error from bad create service discovery service, got %+v", sd)
+	}
+	t.Log("Got expected error from bad service discovery create service", err)
+}
+
+func TestGetServiceDiscovery(t *testing.T) {
+	client := &mockSDClient{}
+	sd, err := getServiceDiscoveryService(context.TODO(), client, aws.String("srv-goodsd"))
+	if err != nil {
+		t.Fatal("expected no error from get service discovery service, got", err)
+	}
+	t.Log("Got service discovery get service output", sd)
+	if !reflect.DeepEqual(sd, goodSd) {
+		t.Fatalf("expected: %+v\n Got: %+v", goodSd, sd)
+	}
+
+	sd, err = getServiceDiscoveryService(context.TODO(), client, aws.String("srv-badsd"))
+	if err == nil {
+		t.Fatalf("expected error from bad get service discovery service, got %+v", sd)
+	}
+	t.Log("Got expected error from bad service discovery service", err)
+}

--- a/orchestration/taskdefinition.go
+++ b/orchestration/taskdefinition.go
@@ -1,0 +1,97 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// processTaskDefinition processes the task definition portion of the input.  If the task definition is provided with
+// the service object, it is used.  Otherwise, if the task definition is defined as input, it will be created.  If neither
+// is true, an error is returned.
+func (o *Orchestrator) processTaskDefinition(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.TaskDefinition, error) {
+	client := o.ECS.Service
+
+	if input.Service.TaskDefinition != nil {
+		log.Infof("using provided task definition %s", aws.StringValue(input.Service.TaskDefinition))
+		taskDefinition, err := getTaskDefinition(ctx, client, input.Service.TaskDefinition)
+		if err != nil {
+			return nil, err
+		}
+		return taskDefinition, nil
+	} else if input.TaskDefinition != nil {
+		newTags := []*ecs.Tag{
+			&ecs.Tag{
+				Key:   aws.String("spinup:org"),
+				Value: aws.String(Org),
+			},
+		}
+
+		for _, t := range input.TaskDefinition.Tags {
+			if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
+				newTags = append(newTags, t)
+			}
+		}
+		input.TaskDefinition.Tags = newTags
+
+		log.Infof("creating task definition %+v", input.TaskDefinition)
+
+		if input.TaskDefinition.ExecutionRoleArn == nil {
+			path := fmt.Sprintf("%s/%s", Org, *input.Cluster.ClusterName)
+			roleARN, err := o.IAM.DefaultTaskExecutionRole(ctx, path)
+			if err != nil {
+				return nil, err
+			}
+
+			input.TaskDefinition.ExecutionRoleArn = &roleARN
+		}
+
+		taskDefinition, err := createTaskDefinition(ctx, client, input.TaskDefinition)
+		if err != nil {
+			return nil, err
+		}
+
+		td := fmt.Sprintf("%s:%d", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
+		input.Service.TaskDefinition = aws.String(td)
+		return taskDefinition, nil
+	}
+
+	return nil, errors.New("taskDefinition or service task definition name is required")
+}
+
+// createTaskDefinition creates a task definition with context and input
+func createTaskDefinition(ctx context.Context, client ecsiface.ECSAPI, input *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error) {
+	if len(input.RequiresCompatibilities) == 0 {
+		input.RequiresCompatibilities = DefaultCompatabilities
+	}
+
+	if input.NetworkMode == nil {
+		input.NetworkMode = DefaultNetworkMode
+	}
+
+	output, err := client.RegisterTaskDefinitionWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.TaskDefinition, err
+}
+
+// getTaskDefinition gets a task definition with context by name
+func getTaskDefinition(ctx context.Context, client ecsiface.ECSAPI, name *string) (*ecs.TaskDefinition, error) {
+	output, err := client.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: name,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output.TaskDefinition, err
+}

--- a/orchestration/taskdefinition_test.go
+++ b/orchestration/taskdefinition_test.go
@@ -1,0 +1,87 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+func (m *mockECSClient) RegisterTaskDefinitionWithContext(ctx aws.Context, input *ecs.RegisterTaskDefinitionInput, opts ...request.Option) (*ecs.RegisterTaskDefinitionOutput, error) {
+	if aws.StringValue(input.Family) == "goodtd" {
+		goodTd.Compatibilities = input.RequiresCompatibilities
+		goodTd.NetworkMode = input.NetworkMode
+		return &ecs.RegisterTaskDefinitionOutput{
+			TaskDefinition: goodTd,
+		}, nil
+	}
+	return nil, errors.New("Failed to create mock task definition")
+}
+
+func (m *mockECSClient) DescribeTaskDefinitionWithContext(ctx aws.Context, input *ecs.DescribeTaskDefinitionInput, opts ...request.Option) (*ecs.DescribeTaskDefinitionOutput, error) {
+	if aws.StringValue(input.TaskDefinition) == "goodtd" {
+		return &ecs.DescribeTaskDefinitionOutput{
+			TaskDefinition: goodTd,
+		}, nil
+	}
+	msg := fmt.Sprintf("Failed to get mock task definition %s", aws.StringValue(input.TaskDefinition))
+	return nil, errors.New(msg)
+}
+
+func TestCreateTaskDefinition(t *testing.T) {
+	client := &mockECSClient{}
+
+	// test a boring task definition
+	td, err := createTaskDefinition(context.TODO(), client, &ecs.RegisterTaskDefinitionInput{Family: aws.String("goodtd")})
+	if err != nil {
+		t.Fatal("expected no error from create task definition, got:", err)
+	}
+	t.Log("got task definition response for good task definition", td)
+	if !reflect.DeepEqual(goodTd, td) {
+		t.Fatalf("Expected %+v\nGot %+v", goodTd, td)
+	}
+
+	// test an error task definition
+	td, err = createTaskDefinition(context.TODO(), client, &ecs.RegisterTaskDefinitionInput{})
+	if err == nil {
+		t.Fatal("expected error from create task definition, got", err, td)
+	}
+	t.Log("got expected error response for bad task definition", err)
+
+	// test a task definition with custom compatabilities
+	td, err = createTaskDefinition(context.TODO(), client, &ecs.RegisterTaskDefinitionInput{
+		Family:                  aws.String("goodtd"),
+		RequiresCompatibilities: aws.StringSlice([]string{"FOOBAR"}),
+	})
+	if err != nil {
+		t.Fatal("expected no error from create task definition with custom compatabilities, got:", err)
+	}
+	if !reflect.DeepEqual([]string{"FOOBAR"}, aws.StringValueSlice(td.Compatibilities)) {
+		t.Fatal("Expected compatabilitieis to be custom:", []string{"FOOBAR"}, "got:", aws.StringValueSlice(td.Compatibilities))
+	}
+	t.Log("got task definition response for good task definition with custom compatablilities", td)
+}
+
+func TestDescribeTaskDefinition(t *testing.T) {
+	client := &mockECSClient{}
+	td, err := getTaskDefinition(context.TODO(), client, aws.String("goodtd"))
+	if err != nil {
+		t.Fatal("expected no error from describe task definition, got:", err)
+	}
+	t.Log("got task definition response for good task definition", td)
+	if !reflect.DeepEqual(goodTd, td) {
+		t.Fatalf("Expected %+v\nGot %+v", goodTd, td)
+	}
+
+	// test an error task definition
+	td, err = getTaskDefinition(context.TODO(), client, aws.String("badtd"))
+	if err == nil {
+		t.Fatal("expected error from create task definition, got", err, td)
+	}
+	t.Log("got expected error response for bad task definition", err)
+}

--- a/secretsmanager/secrets.go
+++ b/secretsmanager/secrets.go
@@ -91,6 +91,8 @@ func (s *SecretsManager) DeleteSecret(ctx context.Context, id string, window int
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
+	log.Infof("Deleting secret %s with window %d", id, window)
+
 	input := secretsmanager.DeleteSecretInput{SecretId: aws.String(id)}
 	if window == 0 {
 		input.ForceDeleteWithoutRecovery = aws.Bool(true)


### PR DESCRIPTION
This breaks out the orchestrion components into separate files in an attempt to solve the name-spacing issues we've hit.  It also makes it look more like the current style APIs we're building in go.   In the process, it adds support for private repository credentials as a separate JSON object (so each container definition can have it's own credential) and cleans up the recursive deletion functionality so it actually works.