### PR TITLE
Handle updating and adding new repository credentials

### DIFF
--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -250,15 +250,6 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 			return nil, err
 		}
 
-		// if we have credentials passed with the update, process those credentials and apply the results to the input
-		if input.Credentials != nil {
-			creds, err := o.processRepositoryCredentialsUpdate(ctx, input)
-			if err != nil {
-				return nil, err
-			}
-			output.Credentials = creds
-		}
-
 		// for each container definition in the active task definition, if the active container deinition *has* repository
 		// credentials defined, check for an incoming container definition with the same name that doesn't already have the
 		// credential defined (ie. an override) and set the credentials parameter from the active container definition
@@ -274,6 +265,15 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 					}
 				}
 			}
+		}
+
+		// if we have credentials passed with the update, process those credentials and apply the results to the input
+		if input.Credentials != nil {
+			creds, err := o.processRepositoryCredentialsUpdate(ctx, input)
+			if err != nil {
+				return nil, err
+			}
+			output.Credentials = creds
 		}
 
 		// set cluster

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -64,6 +64,7 @@ type ServiceOrchestrationUpdateInput struct {
 type ServiceOrchestrationUpdateOutput struct {
 	Service        *ecs.Service
 	TaskDefinition *ecs.TaskDefinition
+	Credentials    map[string]interface{}
 }
 
 // ServiceDeleteInput encapsulates a request to delete a service with optional recursion
@@ -247,6 +248,15 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 		activeTdef, err := o.ECS.GetTaskDefinition(ctx, activeSvc.TaskDefinition)
 		if err != nil {
 			return nil, err
+		}
+
+		// if we have credentials passed with the update, process those credentials and apply the results to the input
+		if input.Credentials != nil {
+			creds, err := o.processRepositoryCredentialsUpdate(ctx, input)
+			if err != nil {
+				return nil, err
+			}
+			output.Credentials = creds
 		}
 
 		// for each container definition in the active task definition, if the active container deinition *has* repository

--- a/orchestration/repositorycredentials.go
+++ b/orchestration/repositorycredentials.go
@@ -28,20 +28,7 @@ func (o *Orchestrator) processRepositoryCredentials(ctx context.Context, input *
 		} else if secret, ok := input.Credentials[name]; ok {
 			log.Infof("creating repository credentials secret for container definition: %s", name)
 
-			newTags := []*secretsmanager.Tag{
-				&secretsmanager.Tag{
-					Key:   aws.String("spinup:org"),
-					Value: aws.String(o.Org),
-				},
-			}
-
-			for _, t := range secret.Tags {
-				if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
-					newTags = append(newTags, t)
-				}
-			}
-			secret.Tags = newTags
-
+			secret.Tags = o.processSecretsmanagerTags(secret.Tags)
 			out, err := client.CreateSecret(ctx, secret)
 			if err != nil {
 				return nil, err
@@ -50,9 +37,9 @@ func (o *Orchestrator) processRepositoryCredentials(ctx context.Context, input *
 			log.Debugf("output: %+v", out)
 
 			log.Infof("setting repository credentials secret for container definition: %s to %s", name, aws.StringValue(out.ARN))
-			cd.SetRepositoryCredentials(&ecs.RepositoryCredentials{
-				CredentialsParameter: out.ARN,
-			})
+
+			cd.SetRepositoryCredentials(&ecs.RepositoryCredentials{CredentialsParameter: out.ARN})
+
 			creds[name] = out
 		} else {
 			log.Infof("assuming container definition %s references a public image, no credentials included", name)
@@ -60,4 +47,79 @@ func (o *Orchestrator) processRepositoryCredentials(ctx context.Context, input *
 	}
 
 	return creds, nil
+}
+
+// processRepositoryCredentialsUpdate processes the passed in repository credentials and applies them appropriately.  If the
+// container definition already has credentials set, assume we are updating the credentials in place. In that case, we shouldn't
+// need to set the repository credentials on the input since they are already applied to the container def.  Otherwise, assume
+// the credentials are new (maybe the container def is new too).  In this case, we create the secret and apply the result to the input.
+func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, input *ServiceOrchestrationUpdateInput) (map[string]interface{}, error) {
+	if len(input.Credentials) == 0 {
+		log.Debugf("no private repository credentials passed")
+		return nil, nil
+	}
+
+	client := o.SecretsManager
+	creds := make(map[string]interface{}, len(input.Credentials))
+	for _, cd := range input.TaskDefinition.ContainerDefinitions {
+		name := aws.StringValue(cd.Name)
+		log.Debugf("processing container definition %s", name)
+		if secret, ok := input.Credentials[name]; ok {
+			if cd.RepositoryCredentials != nil && cd.RepositoryCredentials.CredentialsParameter != nil {
+				secretArn := cd.RepositoryCredentials.CredentialsParameter
+				log.Infof("updating repository credentials secret '%s' for container definition: %s", name, aws.StringValue(secretArn))
+
+				secretUpdate := secretsmanager.PutSecretValueInput{
+					ClientRequestToken: secret.ClientRequestToken,
+					SecretId:           secretArn,
+					SecretString:       secret.SecretString,
+				}
+
+				out, err := client.UpdateSecret(ctx, &secretUpdate)
+				if err != nil {
+					return nil, err
+				}
+
+				log.Debugf("output: %+v", out)
+				creds[name] = out
+			} else {
+				log.Infof("creating new repository credentials secret for container definition: %s", name)
+
+				secret.Tags = o.processSecretsmanagerTags(secret.Tags)
+				out, err := client.CreateSecret(ctx, secret)
+				if err != nil {
+					return nil, err
+				}
+
+				log.Debugf("output: %+v", out)
+
+				log.Infof("setting repository credentials secret for container definition: %s to %s", name, aws.StringValue(out.ARN))
+
+				cd.SetRepositoryCredentials(&ecs.RepositoryCredentials{CredentialsParameter: out.ARN})
+				creds[name] = out
+			}
+		} else {
+			log.Infof("assuming container definition %s references a public image, no credentials included", name)
+		}
+	}
+
+	return creds, nil
+}
+
+func (o *Orchestrator) processSecretsmanagerTags(tags []*secretsmanager.Tag) []*secretsmanager.Tag {
+	log.Debugf("processing secretsmanager tag list %+v", tags)
+	newTags := []*secretsmanager.Tag{
+		&secretsmanager.Tag{
+			Key:   aws.String("spinup:org"),
+			Value: aws.String(o.Org),
+		},
+	}
+
+	for _, t := range tags {
+		if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
+			newTags = append(newTags, t)
+		}
+	}
+	log.Debugf("returning processed secretsmanager tag list %+v", newTags)
+	return newTags
 }

--- a/orchestration/repositorycredentials_test.go
+++ b/orchestration/repositorycredentials_test.go
@@ -49,8 +49,7 @@ func (m *mockSMClient) CreateSecretWithContext(ctx context.Context, input *secre
 	}
 
 	if (input.SecretBinary == nil && input.SecretString == nil) || (input.SecretBinary != nil && input.SecretString != nil) {
-		return nil, awserr.
-			New(secretsmanager.ErrCodeInvalidRequestException, "secret string OR secretbinary is required", nil)
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "secret string OR secretbinary is required", nil)
 	}
 
 	arn := fmt.Sprintf("arn:%s", aws.StringValue(input.Name))
@@ -86,4 +85,280 @@ func TestProcessRepositoryCredentials(t *testing.T) {
 	if !reflect.DeepEqual(credentialsMapOut, out) {
 		t.Fatalf("Expected %+v\nGot %+v", credentialsMapOut, out)
 	}
+}
+
+var testSecrets = []struct {
+	ARN          string
+	Name         string
+	SecretString string
+}{
+	{
+		ARN:          "arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1",
+		Name:         "test-cred-1",
+		SecretString: "ssshhh1",
+	},
+	{
+		ARN:          "arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-2",
+		Name:         "test-cred-2",
+		SecretString: "ssshhh2",
+	},
+	{
+		ARN:          "arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-3",
+		Name:         "test-cred-3",
+		SecretString: "ssshhh3",
+	},
+	{
+		ARN:          "arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-4",
+		Name:         "test-cred-4",
+		SecretString: "ssshhh4",
+	},
+}
+
+func (m *mockSMClient) PutSecretValueWithContext(ctx context.Context, input *secretsmanager.PutSecretValueInput, opts ...request.Option) (*secretsmanager.PutSecretValueOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	if input == nil {
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "invalid input", nil)
+	}
+
+	if (input.SecretBinary == nil && input.SecretString == nil) || (input.SecretBinary != nil && input.SecretString != nil) {
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "secret string OR secretbinary is required", nil)
+	}
+
+	for _, secret := range testSecrets {
+		if aws.StringValue(input.SecretId) == secret.ARN {
+			return &secretsmanager.PutSecretValueOutput{
+				ARN:       aws.String(secret.ARN),
+				Name:      aws.String(secret.Name),
+				VersionId: aws.String("AWSCURRENT"),
+			}, nil
+		}
+	}
+
+	return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "secret doesn't exist", nil)
+}
+
+func TestProcessRepositoryCredentialsUpdate(t *testing.T) {
+	o := Orchestrator{
+		SecretsManager: sm.SecretsManager{Service: &mockSMClient{t: t}},
+	}
+
+	baseTdefInput := ecs.RegisterTaskDefinitionInput{
+		Family: aws.String("tdef1"),
+		Cpu:    aws.String("256"),
+		Memory: aws.String("512"),
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			&ecs.ContainerDefinition{
+				Name:  aws.String("nginx"),
+				Image: aws.String("nginx:alpine"),
+			},
+			&ecs.ContainerDefinition{
+				Name:  aws.String("privateapi"),
+				Image: aws.String("privateapi:latest"),
+			},
+		},
+	}
+
+	var tests = []struct {
+		desc           string
+		tdinput        ecs.RegisterTaskDefinitionInput
+		credentialsMap map[string]*secretsmanager.CreateSecretInput
+		tdresult       ecs.RegisterTaskDefinitionInput
+	}{
+		{
+			desc:           "empty everything",
+			tdinput:        ecs.RegisterTaskDefinitionInput{},
+			credentialsMap: map[string]*secretsmanager.CreateSecretInput{},
+			tdresult:       ecs.RegisterTaskDefinitionInput{},
+		},
+		{
+			desc:           "no creds map",
+			tdinput:        baseTdefInput,
+			credentialsMap: map[string]*secretsmanager.CreateSecretInput{},
+			tdresult:       baseTdefInput,
+		},
+		{
+			desc:    "new creds from map",
+			tdinput: baseTdefInput,
+			credentialsMap: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": &secretsmanager.CreateSecretInput{
+					Name:         aws.String("secret credentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+			tdresult: ecs.RegisterTaskDefinitionInput{
+				Family: aws.String("tdef1"),
+				Cpu:    aws.String("256"),
+				Memory: aws.String("512"),
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					&ecs.ContainerDefinition{
+						Name:  aws.String("nginx"),
+						Image: aws.String("nginx:alpine"),
+					},
+					&ecs.ContainerDefinition{
+						Name:  aws.String("privateapi"),
+						Image: aws.String("privateapi:latest"),
+						RepositoryCredentials: &ecs.RepositoryCredentials{
+							CredentialsParameter: aws.String("arn:secret credentials"),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "update credentials",
+			tdinput: ecs.RegisterTaskDefinitionInput{
+				Family: aws.String("tdef1"),
+				Cpu:    aws.String("256"),
+				Memory: aws.String("512"),
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					&ecs.ContainerDefinition{
+						Name:  aws.String("nginx"),
+						Image: aws.String("nginx:alpine"),
+					},
+					&ecs.ContainerDefinition{
+						Name:  aws.String("privateapi"),
+						Image: aws.String("privateapi:latest"),
+						RepositoryCredentials: &ecs.RepositoryCredentials{
+							CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+						},
+					},
+				},
+			},
+			credentialsMap: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": &secretsmanager.CreateSecretInput{
+					Name:         aws.String("secret credentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+			tdresult: ecs.RegisterTaskDefinitionInput{
+				Family: aws.String("tdef1"),
+				Cpu:    aws.String("256"),
+				Memory: aws.String("512"),
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					&ecs.ContainerDefinition{
+						Name:  aws.String("nginx"),
+						Image: aws.String("nginx:alpine"),
+					},
+					&ecs.ContainerDefinition{
+						Name:  aws.String("privateapi"),
+						Image: aws.String("privateapi:latest"),
+						RepositoryCredentials: &ecs.RepositoryCredentials{
+							CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := o.processRepositoryCredentialsUpdate(context.TODO(), &ServiceOrchestrationUpdateInput{})
+	if err != nil {
+		t.Errorf("expected nil error for processRepositoryCredentialsUpdate, got %s", err)
+	}
+
+	if out != nil {
+		t.Errorf("expected nil output for empty repository credentials, got %+v", out)
+	}
+
+	for _, test := range tests {
+		t.Logf("testing %s", test.desc)
+
+		tdef := test.tdinput
+		out, err = o.processRepositoryCredentialsUpdate(context.TODO(), &ServiceOrchestrationUpdateInput{
+			TaskDefinition: &tdef,
+			Credentials:    test.credentialsMap,
+		})
+		if err != nil {
+			t.Errorf("expected nil error for processRepositoryCredentialsUpdate, got %s", err)
+		}
+
+		t.Log("got processRepositoryCredentials response", out)
+		if !reflect.DeepEqual(tdef, test.tdresult) {
+			t.Fatalf("Expected %+v\nGot %+v", test.tdresult, tdef)
+		}
+	}
+}
+
+func TestProcessSecretsmanagerTags(t *testing.T) {
+	o := Orchestrator{
+		SecretsManager: sm.SecretsManager{Service: &mockSMClient{t: t}},
+		Org:            "testOrg",
+	}
+
+	var tests = []struct {
+		input  []*secretsmanager.Tag
+		output []*secretsmanager.Tag
+	}{
+		{
+			input: []*secretsmanager.Tag{
+				&secretsmanager.Tag{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+			},
+			output: []*secretsmanager.Tag{
+				&secretsmanager.Tag{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+				&secretsmanager.Tag{
+					Key:   aws.String("spinup:org"),
+					Value: aws.String("testOrg"),
+				},
+			},
+		},
+		{
+			input: []*secretsmanager.Tag{
+				&secretsmanager.Tag{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+				&secretsmanager.Tag{
+					Key:   aws.String("spinup:org"),
+					Value: aws.String("someOtherOrg"),
+				},
+				&secretsmanager.Tag{
+					Key:   aws.String("yale:org"),
+					Value: aws.String("someOtherOrg"),
+				},
+			},
+			output: []*secretsmanager.Tag{
+				&secretsmanager.Tag{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+				&secretsmanager.Tag{
+					Key:   aws.String("spinup:org"),
+					Value: aws.String("testOrg"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		out := o.processSecretsmanagerTags(test.input)
+
+		for _, tag := range test.output {
+			exists := false
+			for _, otag := range out {
+				if aws.StringValue(otag.Key) == aws.StringValue(tag.Key) {
+					value := aws.StringValue(tag.Value)
+					ovalue := aws.StringValue(otag.Value)
+					if value != ovalue {
+						t.Errorf("expected tag %s value to be %s, got %s", aws.StringValue(tag.Key), value, ovalue)
+					}
+					exists = true
+					break
+				}
+			}
+
+			if !exists {
+				t.Errorf("expected tag %+v to exist", tag)
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
This should allow for adding new container definitions with credentials, keeping existing credentials and updating credentials for existing container definitions.  The logic should be something like...

* If the passed container definition has a repository credentials ARN and no new credentials are passed, use the passed in repository credentials ARN.
* If the passed container definition has a repository credentials ARN and credentials are passed for the container definition in the credentials map, update the secret with the ARN using the value passed in the credentials map.
* If a container definition has no repository credentials ARN but there are credentials defined in the credentials map for the container definition, create a new secret and associate the ARN with the container definition.
* If the passed container definition has no repository credentials and no new credentials are passed but it had credentials in the previous running task definition, keep those credentials around.  **I don't think this could ever be bad, but might prevent people from blowing their toes off accidentally.**