### PR TITLE
Support setting cloudwatchlogs log-group retention 

### DIFF
--- a/api/handlers_services.go
+++ b/api/handlers_services.go
@@ -309,6 +309,12 @@ func (s *server) ServiceShowHandler(w http.ResponseWriter, r *http.Request) {
 func (s server) newOrchestrator(account string) (*orchestration.Orchestrator, error) {
 	log.Debugf("creating new orchestrator for account %s", account)
 
+	cwlService, ok := s.cwLogsServices[account]
+	if !ok {
+		msg := fmt.Sprintf("cloudwatchkigs service not found for account: %s", account)
+		return nil, apierror.New(apierror.ErrNotFound, msg, nil)
+	}
+
 	ecsService, ok := s.ecsServices[account]
 	if !ok {
 		msg := fmt.Sprintf("ecs service not found for account: %s", account)
@@ -334,6 +340,7 @@ func (s server) newOrchestrator(account string) (*orchestration.Orchestrator, er
 	}
 
 	return &orchestration.Orchestrator{
+		CloudWatchLogs:   cwlService,
 		ECS:              ecsService,
 		IAM:              iamService,
 		SecretsManager:   smService,

--- a/api/handlers_services.go
+++ b/api/handlers_services.go
@@ -311,7 +311,7 @@ func (s server) newOrchestrator(account string) (*orchestration.Orchestrator, er
 
 	cwlService, ok := s.cwLogsServices[account]
 	if !ok {
-		msg := fmt.Sprintf("cloudwatchkigs service not found for account: %s", account)
+		msg := fmt.Sprintf("cloudwatchlogs service not found for account: %s", account)
 		return nil, apierror.New(apierror.ErrNotFound, msg, nil)
 	}
 

--- a/cloudwatchlogs/cloudwatchlogs.go
+++ b/cloudwatchlogs/cloudwatchlogs.go
@@ -43,3 +43,31 @@ func (c *CloudWatchLogs) GetLogEvents(ctx context.Context, input *cloudwatchlogs
 
 	return output, nil
 }
+
+// CreateLogGroup creates a cloudwatchlogs log group
+func (c *CloudWatchLogs) CreateLogGroup(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) error {
+	if input == nil {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	_, err := c.Service.CreateLogGroupWithContext(ctx, input)
+	if err != nil {
+		return ErrCode("failed to create log group", err)
+	}
+
+	return nil
+}
+
+// UpdateRetention changes the retention (in days) for logs in a log group
+func (c *CloudWatchLogs) UpdateRetention(ctx context.Context, input *cloudwatchlogs.PutRetentionPolicyInput) error {
+	if input == nil {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	_, err := c.Service.PutRetentionPolicyWithContext(ctx, input)
+	if err != nil {
+		return ErrCode("failed to update retention policy for log group", err)
+	}
+
+	return nil
+}

--- a/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/cloudwatchlogs/cloudwatchlogs_test.go
@@ -37,6 +37,22 @@ func (m *mockCWLClient) GetLogEventsWithContext(ctx context.Context, input *clou
 	return &cloudwatchlogs.GetLogEventsOutput{}, nil
 }
 
+func (m *mockCWLClient) CreateLogGroupWithContext(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput, opts ...request.Option) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &cloudwatchlogs.CreateLogGroupOutput{}, nil
+}
+
+func (m *mockCWLClient) PutRetentionPolicyWithContext(ctx context.Context, input *cloudwatchlogs.PutRetentionPolicyInput, opts ...request.Option) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &cloudwatchlogs.PutRetentionPolicyOutput{}, nil
+}
+
 func TestNewSession(t *testing.T) {
 	cw := NewSession(common.Account{})
 	to := reflect.TypeOf(cw).String()
@@ -67,7 +83,59 @@ func TestGetLogEvents(t *testing.T) {
 	client = CloudWatchLogs{Service: newmockCWLClient(t, awserr.New(cloudwatchlogs.ErrCodeInvalidOperationException, "The operation is not valid on the specified resource.", nil))}
 	_, err = client.GetLogEvents(context.TODO(), &cloudwatchlogs.GetLogEventsInput{})
 	if err == nil {
+		t.Error("expected error, got nil")
+	} else {
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			t.Logf("got apierror '%s'", aerr)
+		} else {
+			t.Errorf("expected error to be an apierror.Error, got %s", err)
+		}
+	}
+}
+
+func TestCreateLogGroup(t *testing.T) {
+	client := CloudWatchLogs{Service: newmockCWLClient(t, nil)}
+	if err := client.CreateLogGroup(context.TODO(), &cloudwatchlogs.CreateLogGroupInput{
+		LogGroupName: aws.String("log-group-01"),
+	}); err != nil {
 		t.Errorf("expected nil error, got %s", err)
+	}
+
+	if err := client.CreateLogGroup(context.TODO(), nil); err == nil {
+		t.Errorf("expected err for nil input")
+	}
+
+	client = CloudWatchLogs{Service: newmockCWLClient(t, awserr.New(cloudwatchlogs.ErrCodeInvalidOperationException, "The operation is not valid on the specified resource.", nil))}
+	if err := client.CreateLogGroup(context.TODO(), &cloudwatchlogs.CreateLogGroupInput{}); err == nil {
+		t.Error("expected error, got nil")
+	} else {
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			t.Logf("got apierror '%s'", aerr)
+		} else {
+			t.Errorf("expected error to be an apierror.Error, got %s", err)
+		}
+	}
+}
+
+func TestUpdateRetention(t *testing.T) {
+	client := CloudWatchLogs{Service: newmockCWLClient(t, nil)}
+	if err := client.UpdateRetention(context.TODO(), &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String("log-group-01"),
+		RetentionInDays: aws.Int64(int64(365)),
+	}); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+
+	if err := client.UpdateRetention(context.TODO(), nil); err == nil {
+		t.Errorf("expected err for nil input")
+	}
+
+	client = CloudWatchLogs{Service: newmockCWLClient(t, awserr.New(cloudwatchlogs.ErrCodeInvalidOperationException, "The operation is not valid on the specified resource.", nil))}
+	if err := client.UpdateRetention(context.TODO(), &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String("log-group-01"),
+		RetentionInDays: aws.Int64(int64(365)),
+	}); err == nil {
+		t.Error("expected error, got nil")
 	} else {
 		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
 			t.Logf("got apierror '%s'", aerr)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.29.5
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/golang/protobuf v1.3.3 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -3,6 +3,7 @@
 package orchestration
 
 import (
+	"github.com/YaleSpinup/ecs-api/cloudwatchlogs"
 	"github.com/YaleSpinup/ecs-api/ecs"
 	"github.com/YaleSpinup/ecs-api/iam"
 	"github.com/YaleSpinup/ecs-api/secretsmanager"
@@ -29,10 +30,13 @@ var (
 	DefaultSubnets = []*string{}
 	// DefaultSecurityGroups sets a list of default sgs to attach to ENIs
 	DefaultSecurityGroups = []*string{}
+	// DefaultCloudwatchLogsRetention sets the detfault retention (in days) for logs in cloudwatch
+	DefaultCloudwatchLogsRetention = aws.Int64(int64(365))
 )
 
 // Orchestrator holds the service discovery client, iam client, ecs client, secretsmanager client, input, and output
 type Orchestrator struct {
+	CloudWatchLogs cloudwatchlogs.CloudWatchLogs
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#ECS
 	ECS ecs.ECS
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM

--- a/orchestration/taskdefinition.go
+++ b/orchestration/taskdefinition.go
@@ -59,7 +59,7 @@ func (o *Orchestrator) processTaskDefinition(ctx context.Context, input *Service
 			input.TaskDefinition.NetworkMode = DefaultNetworkMode
 		}
 
-		logConfiguration, err := o.processLogConfiguration(ctx, aws.StringValue(input.Cluster.ClusterName), aws.StringValue(input.Service.ServiceName), input.TaskDefinition.Tags)
+		logConfiguration, err := o.processLogConfiguration(ctx, aws.StringValue(input.Cluster.ClusterName), aws.StringValue(input.TaskDefinition.Family), input.TaskDefinition.Tags)
 		if err != nil {
 			return nil, err
 		}
@@ -121,7 +121,7 @@ func (o *Orchestrator) processTaskDefinitionUpdate(ctx context.Context, input *S
 		input.TaskDefinition.NetworkMode = DefaultNetworkMode
 	}
 
-	logConfiguration, err := o.processLogConfiguration(ctx, input.ClusterName, aws.StringValue(input.Service.Service), input.TaskDefinition.Tags)
+	logConfiguration, err := o.processLogConfiguration(ctx, input.ClusterName, aws.StringValue(input.TaskDefinition.Family), input.TaskDefinition.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestration/taskdefinition.go
+++ b/orchestration/taskdefinition.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	log "github.com/sirupsen/logrus"
 )
@@ -55,6 +57,15 @@ func (o *Orchestrator) processTaskDefinition(ctx context.Context, input *Service
 
 		if input.TaskDefinition.NetworkMode == nil {
 			input.TaskDefinition.NetworkMode = DefaultNetworkMode
+		}
+
+		logConfiguration, err := o.processLogConfiguration(ctx, aws.StringValue(input.Cluster.ClusterName), aws.StringValue(input.Service.ServiceName), input.TaskDefinition.Tags)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cd := range input.TaskDefinition.ContainerDefinitions {
+			cd.SetLogConfiguration(logConfiguration)
 		}
 
 		taskDefinition, err := o.ECS.CreateTaskDefinition(ctx, input.TaskDefinition)
@@ -110,7 +121,59 @@ func (o *Orchestrator) processTaskDefinitionUpdate(ctx context.Context, input *S
 		input.TaskDefinition.NetworkMode = DefaultNetworkMode
 	}
 
+	logConfiguration, err := o.processLogConfiguration(ctx, input.ClusterName, aws.StringValue(input.Service.Service), input.TaskDefinition.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cd := range input.TaskDefinition.ContainerDefinitions {
+		cd.SetLogConfiguration(logConfiguration)
+	}
+
 	log.Infof("creating task definition %+v", input.TaskDefinition)
 
 	return o.ECS.CreateTaskDefinition(ctx, input.TaskDefinition)
+}
+
+func (o *Orchestrator) processLogConfiguration(ctx context.Context, logGroup, streamPrefix string, tags []*ecs.Tag) (*ecs.LogConfiguration, error) {
+	if logGroup == "" {
+		return nil, errors.New("cloudwatch logs group name cannot be empty")
+	}
+
+	var tagsMap = make(map[string]*string)
+	for _, tag := range tags {
+		tagsMap[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	err := o.CloudWatchLogs.CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
+		LogGroupName: aws.String(logGroup),
+		Tags:         tagsMap,
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case cloudwatchlogs.ErrCodeResourceAlreadyExistsException:
+				log.Warnf("cloudwatch log group already exists, continuing: (%s)", err)
+			default:
+				return nil, err
+			}
+		}
+	} else {
+		if err := o.CloudWatchLogs.UpdateRetention(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+			LogGroupName:    aws.String(logGroup),
+			RetentionInDays: DefaultCloudwatchLogsRetention,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return &ecs.LogConfiguration{
+		LogDriver: aws.String("awslogs"),
+		Options: map[string]*string{
+			"awslogs-region":        aws.String("us-east-1"),
+			"awslogs-create-group":  aws.String("true"),
+			"awslogs-group":         aws.String(logGroup),
+			"awslogs-stream-prefix": aws.String(streamPrefix),
+		},
+	}, nil
 }

--- a/orchestration/taskdefinition.go
+++ b/orchestration/taskdefinition.go
@@ -158,13 +158,13 @@ func (o *Orchestrator) processLogConfiguration(ctx context.Context, logGroup, st
 				return nil, err
 			}
 		}
-	} else {
-		if err := o.CloudWatchLogs.UpdateRetention(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
-			LogGroupName:    aws.String(logGroup),
-			RetentionInDays: DefaultCloudwatchLogsRetention,
-		}); err != nil {
-			return nil, err
-		}
+	}
+
+	if err := o.CloudWatchLogs.UpdateRetention(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String(logGroup),
+		RetentionInDays: DefaultCloudwatchLogsRetention,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &ecs.LogConfiguration{


### PR DESCRIPTION
Instead of forcing the caller to pass log configuration, assume cloudwatch logs and do the heavy lifting...
* create log-group
* set retention
* set/override the log configuration for each container def in the task def