### PR TITLE
Add support for log paging, single tags object for create and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ DELETE /v1/ecs/{account}/clusters/{cluster}/services/{service}[?recursive=true]
 GET /v1/ecs/{account}/clusters/{cluster}/services/{service}
 GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/events
 GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
 
 // Tasks handlers
 GET /v1/ecs/{account}/clusters/{cluster}/tasks/{task}
@@ -72,17 +75,7 @@ Example request body of new cluster, new task definition, new service registry, 
 ```json
 {
     "cluster": {
-        "clustername": "myclu",
-        "tags": [
-            {
-                "Key": "CreatedBy",
-                "Value": "netid"
-            },
-            {
-                "Key": "OS",
-                "Value": "container"
-            }
-        ]
+        "clustername": "myclu"
     },
     "taskdefinition": {
         "family": "webservers",
@@ -138,12 +131,19 @@ Example request body of new cluster, new task definition, new service registry, 
         "webserver": {
             "Name": "myapp-webserver-cred",
             "SecretString": "{\"username\" : \"supahman\",\"password\" : \"dontkryptonitemebro\"}",
-            "Description": "myapp-webserver-cred",
-            "tags": [
-                {"Key": "Application", "Value": "myapp" }
-            ]
+            "Description": "myapp-webserver-cred"
         }
     },
+    "tags": [
+        {
+            "Key": "CreatedBy",
+            "Value": "netid"
+        },
+        {
+            "Key": "OS",
+            "Value": "container"
+        }
+    ]
 }
 ```
 
@@ -255,13 +255,9 @@ the secret with that ARN will be *overwritten* by the credentials passed in the 
         "privateapi": {
             "Name": "privateapi-cred-1",
             "SecretString": "{\"username\" : \"myorguser\",\"password\" : \"super-sekret-password-string\"}",
-            "Description": "privateapi-creds",
-            "tags": [
-                {"Key": "MyKey", "Value": "MyValue"},
-                {"Key": "Application", "Value": "someprefix"},
-            ]
+            "Description": "privateapi-creds"
         }
-    },
+    }
     "ForceRedeploy": true
 }
 ```
@@ -693,13 +689,13 @@ When only updating tags, you will get an empty response on success. When updatin
 
 ## Development
 
-- Install Go v1.11 or newer
-- Enable Go modules: `export GO111MODULE=on`
-- Create a config: `cp -p config/config.example.json config/config.json`
-- Edit `config.json` and update the parameters
-- Run `go run .` to start the app locally while developing
-- Run `go test ./...` to run all tests
-- Run `go build ./...` to build the binary
+* Install Go v1.11 or newer
+* Enable Go modules: `export GO111MODULE=on`
+* Create a config: `cp -p config/config.example.json config/config.json`
+* Edit `config.json` and update the parameters
+* Run `go run .` to start the app locally while developing
+* Run `go test ./...` to run all tests
+* Run `go build ./...` to build the binary
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ PUT /v1/ecs/{account}/clusters/{cluster}/services
 DELETE /v1/ecs/{account}/clusters/{cluster}/services/{service}[?recursive=true]
 GET /v1/ecs/{account}/clusters/{cluster}/services/{service}
 GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/events
-GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"
-GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
-GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"
-GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
+
+// Log handlers
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="{task}"&container="{container}[&limit={limit}][&seq={seq}][&start={start}&end={end}]"
 
 // Tasks handlers
 GET /v1/ecs/{account}/clusters/{cluster}/tasks/{task}
@@ -257,7 +256,7 @@ the secret with that ARN will be *overwritten* by the credentials passed in the 
             "SecretString": "{\"username\" : \"myorguser\",\"password\" : \"super-sekret-password-string\"}",
             "Description": "privateapi-creds"
         }
-    }
+    },
     "ForceRedeploy": true
 }
 ```
@@ -333,6 +332,23 @@ TODO
 | **400 Bad Request**           | badly formed request                     |
 | **404 Not Found**             | account, cluster or service wasn't found |
 | **500 Internal Server Error** | a server error occurred                  |
+
+
+#### Get logs for a task
+
+GET `/v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"....`
+
+Get the logs for a container running in a task belonging to a service, running in a cluster belonging to an account.  The request can be for just the task and container, in which case up to 10,000 (or 1MB) of the most recent log messages will be returned.  A limit can be passed to limit the number of records returned, and a sequence token, `seq` can be passed to support paging.  Additionally, `start` and `end` times can be passed in milliseconds from the unix epoch.  More details can be found [in the documentation][https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html]
+
+##### Examples
+
+```
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&limit="30"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"
+GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
+```
 
 ## Adhoc Requests
 

--- a/api/handlers_services_test.go
+++ b/api/handlers_services_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+)
+
+func TestParseLogQuery(t *testing.T) {
+	type logQueryParseTest struct {
+		query string
+		input *cloudwatchlogs.GetLogEventsInput
+		err   error
+	}
+
+	tests := []logQueryParseTest{
+		// happy path
+		{
+			query: "",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   nil,
+		},
+		{
+			query: "task=abcdefg&container=hijklmnop",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   nil,
+		},
+		{
+			query: "limit=5",
+			input: &cloudwatchlogs.GetLogEventsInput{
+				Limit: aws.Int64(int64(5)),
+			},
+			err: nil,
+		},
+		{
+			query: "limit=5&seq=abc12345",
+			input: &cloudwatchlogs.GetLogEventsInput{
+				Limit:         aws.Int64(int64(5)),
+				NextToken:     aws.String("abc12345"),
+				StartFromHead: aws.Bool(true),
+			},
+			err: nil,
+		},
+		{
+			query: "start=1234567&end=7654321",
+			input: &cloudwatchlogs.GetLogEventsInput{
+				StartTime: aws.Int64(int64(1234567)),
+				EndTime:   aws.Int64(int64(7654321)),
+			},
+			err: nil,
+		},
+		{
+			query: "limit=5&seq=abc12345&start=1234567&end=7654321",
+			input: &cloudwatchlogs.GetLogEventsInput{
+				Limit:         aws.Int64(int64(5)),
+				NextToken:     aws.String("abc12345"),
+				StartFromHead: aws.Bool(true),
+				StartTime:     aws.Int64(int64(1234567)),
+				EndTime:       aws.Int64(int64(7654321)),
+			},
+			err: nil,
+		},
+		// errors
+		{
+			query: "limit=true",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   errors.New("strconv.ParseInt: parsing \"true\": invalid syntax"),
+		},
+		{
+			query: "limit=abcdefghijklmnopqrstuvwxyz",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   errors.New("strconv.ParseInt: parsing \"abcdefghijklmnopqrstuvwxyz\": invalid syntax"),
+		},
+		{
+			query: "start=true",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   errors.New("strconv.ParseInt: parsing \"true\": invalid syntax"),
+		},
+		{
+			query: "start=abcdefghijklmnopqrstuvwxyz",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   errors.New("strconv.ParseInt: parsing \"abcdefghijklmnopqrstuvwxyz\": invalid syntax"),
+		},
+		{
+			query: "end=true",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   errors.New("strconv.ParseInt: parsing \"true\": invalid syntax"),
+		},
+		{
+			query: "end=abcdefghijklmnopqrstuvwxyz",
+			input: &cloudwatchlogs.GetLogEventsInput{},
+			err:   errors.New("strconv.ParseInt: parsing \"abcdefghijklmnopqrstuvwxyz\": invalid syntax"),
+		},
+	}
+
+	for _, test := range tests {
+		input := &cloudwatchlogs.GetLogEventsInput{}
+		r := &http.Request{
+			URL: &url.URL{
+				RawQuery: test.query,
+			},
+		}
+
+		t.Logf("testing raw query %s", test.query)
+
+		if err := parseLogQuery(r, input); err != nil {
+			if test.err == nil {
+				t.Errorf("expected nil error, got %s", err)
+			} else if test.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", test.err, err)
+			}
+		} else {
+			if !reflect.DeepEqual(input, test.input) {
+				t.Errorf("expected %+v, got %+v", test.input, input)
+			}
+		}
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -22,14 +22,10 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}", s.ServiceDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}", s.ServiceShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/events", s.ServiceEventsHandler).Methods(http.MethodGet)
+
+	// Log handlers
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
 		Queries("task", "{task}", "container", "{container}")
-	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
-		Queries("task", "{task}", "container", "{container}", "limit", "{limit}", "seq", "{seq}")
-	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
-		Queries("task", "{task}", "container", "{container}", "start", "{start}", "end", "{end}")
-	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
-		Queries("task", "{task}", "container", "{container}", "start", "{start}", "end", "{end}", "limit", "{limit}", "seq", "{seq}")
 
 	// Tasks handlers
 	api.HandleFunc("/{account}/clusters/{cluster}/tasks/{task}", s.TaskShowHandler).Methods(http.MethodGet)

--- a/api/routes.go
+++ b/api/routes.go
@@ -22,7 +22,14 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}", s.ServiceDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}", s.ServiceShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/events", s.ServiceEventsHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).Queries("task", "{task}", "container", "{container}")
+	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
+		Queries("task", "{task}", "container", "{container}")
+	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
+		Queries("task", "{task}", "container", "{container}", "limit", "{limit}", "seq", "{seq}")
+	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
+		Queries("task", "{task}", "container", "{container}", "start", "{start}", "end", "{end}")
+	api.HandleFunc("/{account}/clusters/{cluster}/services/{service}/logs", s.ServiceLogsHandler).Methods(http.MethodGet).
+		Queries("task", "{task}", "container", "{container}", "start", "{start}", "end", "{end}", "limit", "{limit}", "seq", "{seq}")
 
 	// Tasks handlers
 	api.HandleFunc("/{account}/clusters/{cluster}/tasks/{task}", s.TaskShowHandler).Methods(http.MethodGet)

--- a/ecs/cluster.go
+++ b/ecs/cluster.go
@@ -19,7 +19,7 @@ func (e *ECS) CreateCluster(ctx context.Context, cluster *ecs.CreateClusterInput
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Debugf("creating cluster with input %+v", cluster)
+	log.Infof("creating cluster %s", aws.StringValue(cluster.ClusterName))
 
 	output, err := e.Service.CreateClusterWithContext(ctx, cluster)
 	if err != nil {
@@ -30,6 +30,12 @@ func (e *ECS) CreateCluster(ctx context.Context, cluster *ecs.CreateClusterInput
 
 // GetCluster gets the details of a cluster with context by the cluster name
 func (e *ECS) GetCluster(ctx context.Context, name *string) (*ecs.Cluster, error) {
+	if name == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting cluster %s", aws.StringValue(name))
+
 	output, err := e.Service.DescribeClustersWithContext(ctx, &ecs.DescribeClustersInput{
 		Clusters: []*string{name},
 	})
@@ -54,6 +60,12 @@ func (e *ECS) GetCluster(ctx context.Context, name *string) (*ecs.Cluster, error
 
 // DeleteCluster deletes a(n empty) cluster
 func (e *ECS) DeleteCluster(ctx context.Context, name *string) error {
+	if name == nil {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting cluster %s", aws.StringValue(name))
+
 	_, err := e.Service.DeleteClusterWithContext(ctx, &ecs.DeleteClusterInput{Cluster: name})
 	if err != nil {
 		return err
@@ -63,6 +75,8 @@ func (e *ECS) DeleteCluster(ctx context.Context, name *string) error {
 
 // DeleteClusterWithRetry continues to retry deleting a cluster until the context is cancelled or it succeeds
 func (e *ECS) DeleteClusterWithRetry(ctx context.Context, arn *string) chan string {
+	log.Infof("deleting cluster %s with retry", aws.StringValue(arn))
+
 	cluChan := make(chan string, 1)
 	go func() {
 		t := 1 * time.Second

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -61,3 +61,19 @@ func (e *ECS) ListTags(ctx context.Context, arn string) ([]*ecs.Tag, error) {
 
 	return output.Tags, nil
 }
+
+func (e *ECS) TagResource(ctx context.Context, input *ecs.TagResourceInput) error {
+	if input == nil {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("tagging ecs resource %s", aws.StringValue(input.ResourceArn))
+
+	_, err := e.Service.TagResourceWithContext(ctx, input)
+	if err != nil {
+		return ErrCode("failed to tag resource", err)
+	}
+
+	log.Debugf("tagged resource with input %+v", input)
+	return nil
+}

--- a/ecs/errors.go
+++ b/ecs/errors.go
@@ -5,9 +5,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 func ErrCode(msg string, err error) error {
+	log.Debugf("processing error code with message '%s' and error '%s'", msg, err)
+
 	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
 		switch aerr.Code() {
 		case

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -11,6 +11,12 @@ import (
 
 // GetService describes an ECS service in a cluster by the service name
 func (e *ECS) GetService(ctx context.Context, cluster, service string) (*ecs.Service, error) {
+	if cluster == "" || service == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting details about service %s/%s", cluster, service)
+
 	output, err := e.Service.DescribeServicesWithContext(ctx, &ecs.DescribeServicesInput{
 		Cluster: aws.String(cluster),
 		Services: []*string{
@@ -36,6 +42,8 @@ func (e *ECS) DeleteService(ctx context.Context, input *ecs.DeleteServiceInput) 
 		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
+	log.Infof("deleting service %s/%s ", aws.StringValue(input.Cluster), aws.StringValue(input.Service))
+
 	output, err := e.Service.DeleteServiceWithContext(ctx, input)
 	if err != nil {
 		return ErrCode("failed to delete service", err)
@@ -51,6 +59,8 @@ func (e *ECS) ListServices(ctx context.Context, cluster string) ([]string, error
 	if cluster == "" {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
+
+	log.Infof("listing services in cluster %s ", cluster)
 
 	input := ecs.ListServicesInput{
 		Cluster:    aws.String(cluster),
@@ -85,7 +95,7 @@ func (e *ECS) CreateService(ctx context.Context, input *ecs.CreateServiceInput) 
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Debugf("creating service with input:\n%+v", input)
+	log.Infof("creating service %s/%s", aws.StringValue(input.Cluster), aws.StringValue(input.ServiceName))
 
 	output, err := e.Service.CreateServiceWithContext(ctx, input)
 	if err != nil {
@@ -101,7 +111,7 @@ func (e *ECS) UpdateService(ctx context.Context, input *ecs.UpdateServiceInput) 
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Debugf("updating service with input:\n%+v", input)
+	log.Infof("updating service %s/%s", aws.StringValue(input.Cluster), aws.StringValue(input.Service))
 
 	output, err := e.Service.UpdateServiceWithContext(ctx, input)
 	if err != nil {

--- a/ecs/task.go
+++ b/ecs/task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	log "github.com/sirupsen/logrus"
 )
 
 // ListTasks collects all of the task ids for a service in a cluster with the given status(s)ß
@@ -21,6 +22,8 @@ func (e *ECS) ListTasks(ctx context.Context, cluster, service string, status []s
 	if status == nil {
 		status = []string{"RUNNING"}
 	}
+
+	log.Infof("listing tasks in %s/%s with status %s", cluster, service, strings.Join(status, ","))
 
 	tasks := []*string{}
 	for _, s := range status {
@@ -58,6 +61,8 @@ func (e *ECS) GetTasks(ctx context.Context, input *ecs.DescribeTasksInput) (*ecs
 	if input == nil {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
+
+	log.Infof("getting cluster %s tasks  %s", aws.StringValue(input.Cluster), strings.Join(aws.StringValueSlice(input.Tasks), ","))
 
 	output, err := e.Service.DescribeTasksWithContext(ctx, input)
 	if err != nil {

--- a/ecs/taskdefinition.go
+++ b/ecs/taskdefinition.go
@@ -15,6 +15,8 @@ func (e *ECS) CreateTaskDefinition(ctx context.Context, input *ecs.RegisterTaskD
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
+	log.Infof("creating task definition '%s'", aws.StringValue(input.Family))
+
 	output, err := e.Service.RegisterTaskDefinitionWithContext(ctx, input)
 	if err != nil {
 		return nil, ErrCode("failed to create task definition", err)
@@ -31,7 +33,7 @@ func (e *ECS) DeleteTaskDefinition(ctx context.Context, taskdefinition *string) 
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Debugf("deregistering task definition '%s'", aws.StringValue(taskdefinition))
+	log.Infof("deregistering task definition '%s'", aws.StringValue(taskdefinition))
 
 	output, err := e.Service.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{TaskDefinition: taskdefinition})
 	if err != nil {
@@ -49,7 +51,7 @@ func (e *ECS) GetTaskDefinition(ctx context.Context, taskdefinition *string) (*e
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Debugf("getting details about task definition '%s'", aws.StringValue(taskdefinition))
+	log.Infof("getting details about task definition '%s'", aws.StringValue(taskdefinition))
 
 	output, err := e.Service.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: taskdefinition,
@@ -70,7 +72,7 @@ func (e *ECS) ListTaskDefinitionRevisions(ctx context.Context, family *string) (
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Debugf("listing task definition revisions with family '%s'", aws.StringValue(family))
+	log.Infof("listing task definition revisions with family '%s'", aws.StringValue(family))
 
 	input := ecs.ListTaskDefinitionsInput{
 		FamilyPrefix: family,

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -1,0 +1,221 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+var testClusters = []*ecs.Cluster{
+	&ecs.Cluster{
+		ActiveServicesCount: aws.Int64(0),
+		ClusterArn:          aws.String("arn:aws:ecs:us-east-1:1234567890:cluster/cluster0"),
+		ClusterName:         aws.String("cluster0"),
+		DefaultCapacityProviderStrategy: []*ecs.CapacityProviderStrategyItem{
+			&ecs.CapacityProviderStrategyItem{
+				Base:             aws.Int64(1),
+				CapacityProvider: aws.String("FARGATE"),
+				Weight:           aws.Int64(0),
+			},
+			&ecs.CapacityProviderStrategyItem{
+				CapacityProvider: aws.String("FARGATE_SPOT"),
+				Weight:           aws.Int64(1),
+			},
+		},
+		PendingTasksCount:                 aws.Int64(0),
+		RegisteredContainerInstancesCount: aws.Int64(0),
+		RunningTasksCount:                 aws.Int64(0),
+		Status:                            aws.String("ACTIVE"),
+	},
+	&ecs.Cluster{
+		ActiveServicesCount: aws.Int64(1),
+		CapacityProviders:   []*string{aws.String("FARGATE")},
+		ClusterArn:          aws.String("arn:aws:ecs:us-east-1:1234567890:cluster/cluster1"),
+		ClusterName:         aws.String("cluster1"),
+		DefaultCapacityProviderStrategy: []*ecs.CapacityProviderStrategyItem{
+			&ecs.CapacityProviderStrategyItem{
+				Base:             aws.Int64(1),
+				CapacityProvider: aws.String("FARGATE"),
+				Weight:           aws.Int64(0),
+			},
+			&ecs.CapacityProviderStrategyItem{
+				CapacityProvider: aws.String("FARGATE_SPOT"),
+				Weight:           aws.Int64(1),
+			},
+		},
+		PendingTasksCount:                 aws.Int64(1),
+		RegisteredContainerInstancesCount: aws.Int64(1),
+		RunningTasksCount:                 aws.Int64(1),
+		Status:                            aws.String("ACTIVE"),
+	},
+	&ecs.Cluster{
+		ActiveServicesCount: aws.Int64(2),
+		CapacityProviders:   []*string{aws.String("FARGATE_SPOT")},
+		ClusterArn:          aws.String("arn:aws:ecs:us-east-1:1234567890:cluster/cluster2"),
+		ClusterName:         aws.String("cluster2"),
+		DefaultCapacityProviderStrategy: []*ecs.CapacityProviderStrategyItem{
+			&ecs.CapacityProviderStrategyItem{
+				Base:             aws.Int64(1),
+				CapacityProvider: aws.String("FARGATE"),
+				Weight:           aws.Int64(0),
+			},
+			&ecs.CapacityProviderStrategyItem{
+				CapacityProvider: aws.String("FARGATE_SPOT"),
+				Weight:           aws.Int64(1),
+			},
+		},
+		PendingTasksCount:                 aws.Int64(1),
+		RegisteredContainerInstancesCount: aws.Int64(1),
+		RunningTasksCount:                 aws.Int64(1),
+		Status:                            aws.String("ACTIVE"),
+		Tags: []*ecs.Tag{
+			&ecs.Tag{
+				Key:   aws.String("fuz"),
+				Value: aws.String("biz"),
+			},
+		},
+	},
+	&ecs.Cluster{
+		ActiveServicesCount: aws.Int64(3),
+		CapacityProviders: []*string{
+			aws.String("FARGATE"),
+			aws.String("FARGATE_SPOT"),
+		},
+		ClusterArn:  aws.String("arn:aws:ecs:us-east-1:1234567890:cluster/cluster3"),
+		ClusterName: aws.String("cluster3"),
+		DefaultCapacityProviderStrategy: []*ecs.CapacityProviderStrategyItem{
+			&ecs.CapacityProviderStrategyItem{
+				Base:             aws.Int64(1),
+				CapacityProvider: aws.String("FARGATE"),
+				Weight:           aws.Int64(0),
+			},
+			&ecs.CapacityProviderStrategyItem{
+				CapacityProvider: aws.String("FARGATE_SPOT"),
+				Weight:           aws.Int64(1),
+			},
+		},
+		PendingTasksCount:                 aws.Int64(1),
+		RegisteredContainerInstancesCount: aws.Int64(1),
+		RunningTasksCount:                 aws.Int64(1),
+		Status:                            aws.String("ACTIVE"),
+		Tags: []*ecs.Tag{
+			&ecs.Tag{
+				Key:   aws.String("foo"),
+				Value: aws.String("bar"),
+			},
+		},
+	},
+}
+
+func (m *mockECSClient) CreateClusterWithContext(ctx context.Context, input *ecs.CreateClusterInput, opts ...request.Option) (*ecs.CreateClusterOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	for _, cluster := range testClusters {
+		if aws.StringValue(input.ClusterName) == aws.StringValue(cluster.ClusterName) {
+			return &ecs.CreateClusterOutput{
+				Cluster: cluster,
+			}, nil
+		}
+
+	}
+
+	return nil, errors.New("boom!")
+}
+
+func (m *mockECSClient) DescribeClustersWithContext(ctx aws.Context, input *ecs.DescribeClustersInput, opts ...request.Option) (*ecs.DescribeClustersOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	clusters := []*ecs.Cluster{}
+	for _, inputClu := range input.Clusters {
+		for _, cluster := range testClusters {
+			if aws.StringValue(inputClu) == aws.StringValue(cluster.ClusterName) {
+				clusters = append(clusters, cluster)
+			}
+
+		}
+	}
+
+	return &ecs.DescribeClustersOutput{Clusters: clusters}, nil
+}
+
+func TestProcessCluster(t *testing.T) {
+	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil)
+
+	if _, err := orchestrator.processCluster(context.TODO(), &ServiceOrchestrationInput{}); err == nil {
+		t.Error("expected error for missing cluster, got nil")
+	}
+
+	for _, c := range testClusters {
+		// test including cluster in service
+		input := ServiceOrchestrationInput{
+			Service: &ecs.CreateServiceInput{
+				Cluster: c.ClusterName,
+			},
+		}
+
+		out, err := orchestrator.processCluster(context.TODO(), &input)
+		if err != nil {
+			t.Errorf("expected nil error, got %s", err)
+		}
+		t.Logf("got output from process cluster %+v", out)
+
+		if !reflect.DeepEqual(out, c) {
+			t.Errorf("expected %+v, got %+v", c, out)
+		}
+
+	}
+
+	for _, c := range testClusters {
+		// test including cluster in service
+		input := ServiceOrchestrationInput{
+			Service: &ecs.CreateServiceInput{},
+			Cluster: &ecs.CreateClusterInput{
+				CapacityProviders: c.CapacityProviders,
+				ClusterName:       c.ClusterName,
+				Tags:              c.Tags,
+			},
+		}
+
+		out, err := orchestrator.processCluster(context.TODO(), &input)
+		if err != nil {
+			t.Errorf("expected nil error, got %s", err)
+		}
+		t.Logf("got output from process cluster %+v", out)
+
+		if !reflect.DeepEqual(out, c) {
+			t.Errorf("expected %+v, got %+v", c, out)
+		}
+	}
+
+	err := awserr.New(ecs.ErrCodeUpdateInProgressException, "broke", nil)
+	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil)
+
+	input := ServiceOrchestrationInput{
+		Service: &ecs.CreateServiceInput{
+			Cluster: aws.String("cluster0"),
+		},
+	}
+	if _, err := orchestrator.processCluster(context.TODO(), &input); err == nil {
+		t.Error("expected error, got nil")
+	}
+
+	input = ServiceOrchestrationInput{
+		Service: &ecs.CreateServiceInput{},
+		Cluster: &ecs.CreateClusterInput{
+			ClusterName: aws.String("cluster0"),
+		},
+	}
+	if _, err := orchestrator.processCluster(context.TODO(), &input); err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -285,28 +285,6 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 			input.TaskDefinition.Tags = active.Service.Tags
 		}
 
-		// TODO: remove this logic, I don't think we ended up using/needing it and its confusing.
-		// // for each container definition in the active task definition, if the active container deinition *has* repository
-		// // credentials defined, check for an incoming container definition with the same name that doesn't already have the
-		// // credential defined (ie. an override) and set the credentials parameter from the active container definition
-		// activeCreds := make(map[string]*string)
-		// for _, cdef := range active.TaskDefinition.ContainerDefinitions {
-		// 	if cdef.RepositoryCredentials != nil && cdef.RepositoryCredentials.CredentialsParameter != nil {
-		// 		cname := aws.StringValue(cdef.Name)
-		// 		activeCreds[cname] = cdef.RepositoryCredentials.CredentialsParameter
-		// 	}
-		// }
-		//
-		// for _, cdef := range input.TaskDefinition.ContainerDefinitions {
-		// 	cname := aws.StringValue(cdef.Name)
-		// 	if creds, ok := activeCreds[cname]; ok && cdef.RepositoryCredentials == nil {
-		// 		log.Debugf("setting credentials from active task def/container def %s: %+v", cname, creds)
-		// 		cdef.SetRepositoryCredentials(&ecs.RepositoryCredentials{
-		// 			CredentialsParameter: creds,
-		// 		})
-		// 	}
-		// }
-
 		// if we have credentials passed with the update, process those credentials and apply the results to the input
 		if input.Credentials != nil {
 			creds, err := o.processRepositoryCredentialsUpdate(ctx, input)

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -16,6 +16,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type Tag struct {
+	Key   *string
+	Value *string
+}
+
 // ServiceOrchestrationInput encapsulates a single request for a service
 type ServiceOrchestrationInput struct {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#CreateClusterInput
@@ -29,6 +34,8 @@ type ServiceOrchestrationInput struct {
 	Service *ecs.CreateServiceInput
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/servicediscovery/#CreateServiceInput
 	ServiceRegistry *servicediscovery.CreateServiceInput
+	// slice of tags to be applied to all resources
+	Tags []*Tag
 }
 
 // ServiceOrchestrationOutput is the output structure for service orchestration
@@ -56,7 +63,7 @@ type ServiceOrchestrationUpdateInput struct {
 	Credentials map[string]*secretsmanager.CreateSecretInput
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#UpdateServiceInput
 	Service            *ecs.UpdateServiceInput
-	Tags               []*ecs.Tag
+	Tags               []*Tag
 	ForceNewDeployment bool
 }
 
@@ -65,6 +72,7 @@ type ServiceOrchestrationUpdateOutput struct {
 	Service        *ecs.Service
 	TaskDefinition *ecs.TaskDefinition
 	Credentials    map[string]interface{}
+	Tags           []*Tag
 }
 
 // ServiceDeleteInput encapsulates a request to delete a service with optional recursion
@@ -80,6 +88,12 @@ func (o *Orchestrator) CreateService(ctx context.Context, input *ServiceOrchestr
 	if input.Service == nil {
 		return nil, errors.New("service definition is required")
 	}
+
+	ct, err := cleanTags(o.Org, input.Tags)
+	if err != nil {
+		return nil, err
+	}
+	input.Tags = ct
 
 	output := &ServiceOrchestrationOutput{}
 	cluster, err := o.processCluster(ctx, input)
@@ -237,35 +251,61 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 		return nil, errors.New("expected update")
 	}
 
-	output := &ServiceOrchestrationUpdateOutput{}
-	activeSvc, err := o.ECS.GetService(ctx, cluster, service)
+	// set cluster
+	input.ClusterName = cluster
+
+	active := &ServiceOrchestrationUpdateOutput{}
+
+	// get active service
+	svc, err := o.ECS.GetService(ctx, cluster, service)
 	if err != nil {
 		return nil, err
 	}
-	output.Service = activeSvc
+
+	// GetService doesn't include tag information, lets add it
+	tags, err := o.ECS.ListTags(ctx, aws.StringValue(svc.ServiceArn))
+	if err != nil {
+		return nil, err
+	}
+	svc.Tags = tags
+
+	active.Service = svc
+	log.Debugf("active service: %+v", active.Service)
 
 	if input.TaskDefinition != nil {
-		activeTdef, err := o.ECS.GetTaskDefinition(ctx, activeSvc.TaskDefinition)
+		// get the active task def
+		tdef, err := o.ECS.GetTaskDefinition(ctx, active.Service.TaskDefinition)
 		if err != nil {
 			return nil, err
 		}
+		active.TaskDefinition = tdef
 
-		// for each container definition in the active task definition, if the active container deinition *has* repository
-		// credentials defined, check for an incoming container definition with the same name that doesn't already have the
-		// credential defined (ie. an override) and set the credentials parameter from the active container definition
-		for _, activeCdef := range activeTdef.ContainerDefinitions {
-			if activeCdef.RepositoryCredentials != nil {
-				for _, newCdef := range input.TaskDefinition.ContainerDefinitions {
-					if aws.StringValue(activeCdef.Name) == aws.StringValue(newCdef.Name) {
-						if newCdef.RepositoryCredentials == nil {
-							log.Debugf("setting repo credentials from active task def/container def: %+v", activeCdef.RepositoryCredentials)
-							newCdef.SetRepositoryCredentials(activeCdef.RepositoryCredentials)
-						}
-						break
-					}
-				}
-			}
+		// if the tags are empty for the task definition, apply the existing tags
+		if input.TaskDefinition.Tags == nil {
+			input.TaskDefinition.Tags = active.Service.Tags
 		}
+
+		// TODO: remove this logic, I don't think we ended up using/needing it and its confusing.
+		// // for each container definition in the active task definition, if the active container deinition *has* repository
+		// // credentials defined, check for an incoming container definition with the same name that doesn't already have the
+		// // credential defined (ie. an override) and set the credentials parameter from the active container definition
+		// activeCreds := make(map[string]*string)
+		// for _, cdef := range active.TaskDefinition.ContainerDefinitions {
+		// 	if cdef.RepositoryCredentials != nil && cdef.RepositoryCredentials.CredentialsParameter != nil {
+		// 		cname := aws.StringValue(cdef.Name)
+		// 		activeCreds[cname] = cdef.RepositoryCredentials.CredentialsParameter
+		// 	}
+		// }
+		//
+		// for _, cdef := range input.TaskDefinition.ContainerDefinitions {
+		// 	cname := aws.StringValue(cdef.Name)
+		// 	if creds, ok := activeCreds[cname]; ok && cdef.RepositoryCredentials == nil {
+		// 		log.Debugf("setting credentials from active task def/container def %s: %+v", cname, creds)
+		// 		cdef.SetRepositoryCredentials(&ecs.RepositoryCredentials{
+		// 			CredentialsParameter: creds,
+		// 		})
+		// 	}
+		// }
 
 		// if we have credentials passed with the update, process those credentials and apply the results to the input
 		if input.Credentials != nil {
@@ -273,119 +313,108 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 			if err != nil {
 				return nil, err
 			}
-			output.Credentials = creds
+			active.Credentials = creds
+			log.Debugf("processed update of repository credentials: %+v", active.Credentials)
 		}
 
-		// set cluster
-		input.ClusterName = cluster
+		if err := o.processTaskDefinitionUpdate(ctx, input, active); err != nil {
+			return nil, err
+		}
 
-		td, err := o.processTaskDefinitionUpdate(ctx, input)
+		log.Debugf("processed update of task definition: %+v", active.TaskDefinition)
+	}
+
+	// process updating the service
+	if err = o.processServiceUpdate(ctx, input, active); err != nil {
+		return nil, err
+	}
+	log.Debugf("processed update of service: %+v", active.Service)
+
+	// if we have tags to update
+	if input.Tags != nil {
+		log.Infof("updating tags for service %s and components", aws.StringValue(active.Service.ServiceName))
+
+		input.Tags, err = cleanTags(o.Org, input.Tags)
 		if err != nil {
 			return nil, err
 		}
 
-		log.Debugf("orchestrated create of task definition: %+v", td)
-
-		if input.Service == nil {
-			input.Service = &ecs.UpdateServiceInput{}
+		ecsTags := make([]*ecs.Tag, len(input.Tags))
+		smTags := make([]*secretsmanager.Tag, len(input.Tags))
+		for i, t := range input.Tags {
+			ecsTags[i] = &ecs.Tag{Key: t.Key, Value: t.Value}
+			smTags[i] = &secretsmanager.Tag{Key: t.Key, Value: t.Value}
 		}
-
-		// apply new task definition ARN to the service update
-		input.Service.TaskDefinition = td.TaskDefinitionArn
-		output.TaskDefinition = td
-	}
-
-	if input.Service != nil {
-		// set cluster and service, disallow assigning public IP, default to active service network config
-		u := input.Service
-		u.Cluster = activeSvc.ClusterArn
-		u.Service = activeSvc.ServiceArn
-		if u.NetworkConfiguration != nil && u.NetworkConfiguration.AwsvpcConfiguration != nil {
-			subnets := activeSvc.NetworkConfiguration.AwsvpcConfiguration.Subnets
-			if u.NetworkConfiguration.AwsvpcConfiguration.Subnets != nil {
-				subnets = u.NetworkConfiguration.AwsvpcConfiguration.Subnets
-			}
-
-			sgs := activeSvc.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups
-			if u.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups != nil {
-				sgs = u.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups
-			}
-
-			u.NetworkConfiguration.AwsvpcConfiguration = &ecs.AwsVpcConfiguration{
-				AssignPublicIp: aws.String("DISABLED"),
-				Subnets:        subnets,
-				SecurityGroups: sgs,
-			}
-		}
-
-		out, err := o.ECS.UpdateService(ctx, u)
-		if err != nil {
-			return output, err
-		}
-
-		// override active service with new service
-		activeSvc = out.Service
-
-		output.Service = out.Service
-	} else if input.ForceNewDeployment {
-		out, err := o.ECS.UpdateService(ctx, &ecs.UpdateServiceInput{
-			ForceNewDeployment: aws.Bool(true),
-			Service:            activeSvc.ServiceName,
-			Cluster:            activeSvc.ClusterArn,
-		})
-		if err != nil {
-			return output, err
-		}
-		output.Service = out.Service
-	}
-
-	// if we have tags to update
-	if input.Tags != nil {
-		newTags := []*ecs.Tag{
-			&ecs.Tag{
-				Key:   aws.String("spinup:org"),
-				Value: aws.String(o.Org),
-			},
-		}
-
-		for _, t := range input.Tags {
-			if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
-				newTags = append(newTags, t)
-			}
-
-			if aws.StringValue(t.Key) == "spinup:org" || aws.StringValue(t.Key) == "yale:org" {
-				if aws.StringValue(t.Value) != o.Org {
-					msg := fmt.Sprintf("%s/%s is not a part of our org (%s)", cluster, service, o.Org)
-					return output, errors.New(msg)
-				}
-			}
-		}
-		input.Tags = newTags
 
 		// tag service
-		if _, err = o.ECS.Service.TagResourceWithContext(ctx, &ecs.TagResourceInput{
-			ResourceArn: activeSvc.ServiceArn,
-			Tags:        input.Tags,
+		if err := o.ECS.TagResource(ctx, &ecs.TagResourceInput{
+			ResourceArn: active.Service.ServiceArn,
+			Tags:        ecsTags,
 		}); err != nil {
-			return output, err
+			return nil, err
 		}
 
 		// tag task definition
-		if _, err = o.ECS.Service.TagResourceWithContext(ctx, &ecs.TagResourceInput{
-			ResourceArn: activeSvc.TaskDefinition,
-			Tags:        input.Tags,
+		if err = o.ECS.TagResource(ctx, &ecs.TagResourceInput{
+			ResourceArn: active.Service.TaskDefinition,
+			Tags:        ecsTags,
 		}); err != nil {
-			return output, err
+			return nil, err
 		}
 
 		// tag cluster
-		if _, err = o.ECS.Service.TagResourceWithContext(ctx, &ecs.TagResourceInput{
-			ResourceArn: activeSvc.ClusterArn,
-			Tags:        input.Tags,
+		if err = o.ECS.TagResource(ctx, &ecs.TagResourceInput{
+			ResourceArn: active.Service.ClusterArn,
+			Tags:        ecsTags,
 		}); err != nil {
-			return output, err
+			return nil, err
+		}
+
+		// tag secrets
+		// but first we need the active task definition
+		if active.TaskDefinition == nil {
+			// get the active task def
+			tdef, err := o.ECS.GetTaskDefinition(ctx, active.Service.TaskDefinition)
+			if err != nil {
+				return nil, err
+			}
+			active.TaskDefinition = tdef
+		}
+
+		for _, containerDef := range active.TaskDefinition.ContainerDefinitions {
+			repositoryCredentials := containerDef.RepositoryCredentials
+			if repositoryCredentials != nil && repositoryCredentials.CredentialsParameter != nil {
+				credentialsArn := aws.StringValue(repositoryCredentials.CredentialsParameter)
+				if err := o.SecretsManager.UpdateSecretTags(ctx, credentialsArn, smTags); err != nil {
+					return nil, err
+				}
+			}
 		}
 	}
 
-	return output, nil
+	return active, nil
+}
+
+func cleanTags(org string, tags []*Tag) ([]*Tag, error) {
+	cleanTags := []*Tag{
+		&Tag{
+			Key:   aws.String("spinup:org"),
+			Value: aws.String(org),
+		},
+	}
+
+	for _, t := range tags {
+		if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" {
+			cleanTags = append(cleanTags, &Tag{Key: t.Key, Value: t.Value})
+		}
+
+		if aws.StringValue(t.Key) == "spinup:org" || aws.StringValue(t.Key) == "yale:org" {
+			if aws.StringValue(t.Value) != org {
+				msg := fmt.Sprintf("not a part of our org (%s)", org)
+				return nil, errors.New(msg)
+			}
+		}
+	}
+
+	return cleanTags, nil
 }

--- a/orchestration/orchestration_test.go
+++ b/orchestration/orchestration_test.go
@@ -3,6 +3,8 @@ package orchestration
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
+
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
@@ -11,6 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
+
+type mockCWLClient struct {
+	cloudwatchlogsiface.CloudWatchLogsAPI
+	t   *testing.T
+	err error
+}
 
 type mockECSClient struct {
 	ecsiface.ECSAPI
@@ -61,3 +69,38 @@ var (
 		},
 	}
 )
+
+func newMockCWLClient(t *testing.T, err error) cloudwatchlogsiface.CloudWatchLogsAPI {
+	return &mockCWLClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func newMockECSClient(t *testing.T, err error) ecsiface.ECSAPI {
+	return &mockECSClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func newMockIAMClient(t *testing.T, err error) iamiface.IAMAPI {
+	return &mockIAMClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func newMockSMClient(t *testing.T, err error) secretsmanageriface.SecretsManagerAPI {
+	return &mockSMClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func newMockSDClient(t *testing.T, err error) servicediscoveryiface.ServiceDiscoveryAPI {
+	return &mockSDClient{
+		t:   t,
+		err: err,
+	}
+}

--- a/orchestration/orchestrator_test.go
+++ b/orchestration/orchestrator_test.go
@@ -1,0 +1,24 @@
+package orchestration
+
+import (
+	"testing"
+
+	"github.com/YaleSpinup/ecs-api/cloudwatchlogs"
+	"github.com/YaleSpinup/ecs-api/ecs"
+	"github.com/YaleSpinup/ecs-api/iam"
+	"github.com/YaleSpinup/ecs-api/secretsmanager"
+	"github.com/YaleSpinup/ecs-api/servicediscovery"
+	"github.com/google/uuid"
+)
+
+func newMockOrchestrator(t *testing.T, org string, cwlerr, ecserr, iamerr, smerr, sderr error) *Orchestrator {
+	return &Orchestrator{
+		CloudWatchLogs:   cloudwatchlogs.CloudWatchLogs{Service: newMockCWLClient(t, cwlerr)},
+		ECS:              ecs.ECS{Service: newMockECSClient(t, ecserr)},
+		IAM:              iam.IAM{Service: newMockIAMClient(t, iamerr)},
+		SecretsManager:   secretsmanager.SecretsManager{Service: newMockSMClient(t, smerr)},
+		ServiceDiscovery: servicediscovery.ServiceDiscovery{Service: newMockSDClient(t, sderr)},
+		Token:            uuid.New().String(),
+		Org:              org,
+	}
+}

--- a/orchestration/repositorycredentials_test.go
+++ b/orchestration/repositorycredentials_test.go
@@ -289,12 +289,12 @@ func TestProcessSecretsmanagerTags(t *testing.T) {
 	}
 
 	var tests = []struct {
-		input  []*secretsmanager.Tag
+		input  []*Tag
 		output []*secretsmanager.Tag
 	}{
 		{
-			input: []*secretsmanager.Tag{
-				&secretsmanager.Tag{
+			input: []*Tag{
+				&Tag{
 					Key:   aws.String("foo"),
 					Value: aws.String("bar"),
 				},
@@ -303,25 +303,17 @@ func TestProcessSecretsmanagerTags(t *testing.T) {
 				&secretsmanager.Tag{
 					Key:   aws.String("foo"),
 					Value: aws.String("bar"),
-				},
-				&secretsmanager.Tag{
-					Key:   aws.String("spinup:org"),
-					Value: aws.String("testOrg"),
 				},
 			},
 		},
 		{
-			input: []*secretsmanager.Tag{
-				&secretsmanager.Tag{
+			input: []*Tag{
+				&Tag{
 					Key:   aws.String("foo"),
 					Value: aws.String("bar"),
 				},
-				&secretsmanager.Tag{
+				&Tag{
 					Key:   aws.String("spinup:org"),
-					Value: aws.String("someOtherOrg"),
-				},
-				&secretsmanager.Tag{
-					Key:   aws.String("yale:org"),
 					Value: aws.String("someOtherOrg"),
 				},
 			},
@@ -332,7 +324,7 @@ func TestProcessSecretsmanagerTags(t *testing.T) {
 				},
 				&secretsmanager.Tag{
 					Key:   aws.String("spinup:org"),
-					Value: aws.String("testOrg"),
+					Value: aws.String("someOtherOrg"),
 				},
 			},
 		},
@@ -341,9 +333,16 @@ func TestProcessSecretsmanagerTags(t *testing.T) {
 	for _, test := range tests {
 		out := o.processSecretsmanagerTags(test.input)
 
+		if !reflect.DeepEqual(test.output, out) {
+			t.Errorf("expected %+v, got %+v", test.output, out)
+		}
+
 		for _, tag := range test.output {
 			exists := false
+			t.Logf("testing for test tag key: %v, value: %v", tag.Key, tag.Value)
+
 			for _, otag := range out {
+				t.Logf("testing output tag key: %v, value: %v", otag.Key, otag.Value)
 				if aws.StringValue(otag.Key) == aws.StringValue(tag.Key) {
 					value := aws.StringValue(tag.Value)
 					ovalue := aws.StringValue(otag.Value)

--- a/secretsmanager/secrets.go
+++ b/secretsmanager/secrets.go
@@ -31,12 +31,14 @@ func (s *SecretsManager) CreateSecret(ctx context.Context, input *secretsmanager
 		return nil, ErrCode("failed to create secret", err)
 	}
 
+	log.Debugf("create secret output: %+v", out)
+
 	return out, nil
 }
 
 // ListSecretsWithFilter lists all of the secrets with a passed filter function
 func (s *SecretsManager) ListSecretsWithFilter(ctx context.Context, filter func(*secretsmanager.SecretListEntry) bool) ([]*string, error) {
-	log.Info("listing secretsmanager secrets")
+	log.Info("listing secretsmanager secrets with filter")
 	secrets := []*string{}
 
 	i := 0
@@ -61,6 +63,8 @@ func (s *SecretsManager) ListSecretsWithFilter(ctx context.Context, filter func(
 		i++
 	}
 
+	log.Debugf("returning list of secrets: %+v", secrets)
+
 	return secrets, nil
 }
 
@@ -71,7 +75,7 @@ func (s *SecretsManager) GetSecretMetaDataWithFilter(ctx context.Context, id str
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Infof("describing secretsmanager secret %s", id)
+	log.Infof("describing secretsmanager secret %s with filter", id)
 
 	out, err := s.Service.DescribeSecretWithContext(ctx, &secretsmanager.DescribeSecretInput{SecretId: aws.String(id)})
 	if err != nil {
@@ -79,6 +83,7 @@ func (s *SecretsManager) GetSecretMetaDataWithFilter(ctx context.Context, id str
 	}
 
 	if filter(out) {
+		log.Debugf("returning secret metadata %+v", out)
 		return out, nil
 	}
 
@@ -91,7 +96,7 @@ func (s *SecretsManager) DeleteSecret(ctx context.Context, id string, window int
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Infof("Deleting secret %s with window %d", id, window)
+	log.Infof("deleting secret %s with window %d", id, window)
 
 	input := secretsmanager.DeleteSecretInput{SecretId: aws.String(id)}
 	if window == 0 {
@@ -108,6 +113,8 @@ func (s *SecretsManager) DeleteSecret(ctx context.Context, id string, window int
 		msg := fmt.Sprintf("failed to delete secret with id %s", id)
 		return nil, ErrCode(msg, err)
 	}
+
+	log.Debugf("returning delete secret output %+v", out)
 
 	return out, nil
 }
@@ -133,6 +140,8 @@ func (s *SecretsManager) UpdateSecret(ctx context.Context, input *secretsmanager
 		return nil, ErrCode("failed to update secret", err)
 	}
 
+	log.Debugf("returning secret update output %+v", out)
+
 	return out, nil
 }
 
@@ -142,7 +151,7 @@ func (s *SecretsManager) UpdateSecretTags(ctx context.Context, id string, tags [
 		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Infof("updating secret %s", id)
+	log.Infof("tagging secret %s", id)
 
 	_, err := s.Service.TagResourceWithContext(ctx, &secretsmanager.TagResourceInput{
 		SecretId: aws.String(id),


### PR DESCRIPTION
* move the `Tags` object to the top level of the JSON production (so it doesn't have to be repeated in all of the components) for create and update service endpoints
* add support log log paging by passing sequence and limit
* add support for log filtering by time by passing a start and end time (in ms since the epoch)