### PR TITLE
Update processRepositoryCredentialsUpdate to work for known cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,12 @@ require (
 	github.com/YaleSpinup/apierror v0.1.0
 	github.com/aws/aws-sdk-go v1.33.5
 	github.com/docker/distribution v2.7.1+incompatible
-	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
-	github.com/prometheus/common v0.10.0 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.6.0
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/aws/aws-sdk-go v1.31.11 h1:Uz7VGg3giOV9Z4SlLdXO6RHafArHbK59vSc6mnzYjGU=
-github.com/aws/aws-sdk-go v1.31.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.5 h1:p2fr1ryvNTU6avUWLI+/H7FGv0TBIjzVM5WDgXBBv4U=
 github.com/aws/aws-sdk-go v1.33.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -52,6 +50,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -63,7 +62,6 @@ github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
-github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -94,8 +92,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
-github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
-github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -104,14 +100,10 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
-github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
-github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
-github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
@@ -132,8 +124,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20200602180216-279210d13fed h1:g4KENRiCMEx58Q7/ecwfT0N2o8z35Fnbsjig/Alf2T4=
-golang.org/x/crypto v0.0.0-20200602180216-279210d13fed/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -162,9 +152,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
-golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -193,8 +180,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
-google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -302,14 +302,8 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 			input.TaskDefinition.Tags = active.Service.Tags
 		}
 
-		// if we have credentials passed with the update, process those credentials and apply the results to the input
-		if input.Credentials != nil {
-			creds, err := o.processRepositoryCredentialsUpdate(ctx, input)
-			if err != nil {
-				return nil, err
-			}
-			active.Credentials = creds
-			log.Debugf("processed update of repository credentials: %+v", active.Credentials)
+		if err := o.processRepositoryCredentialsUpdate(ctx, input, active); err != nil {
+			return nil, err
 		}
 
 		if err := o.processTaskDefinitionUpdate(ctx, input, active); err != nil {

--- a/orchestration/repositorycredentials.go
+++ b/orchestration/repositorycredentials.go
@@ -2,6 +2,7 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -85,80 +86,150 @@ func (o *Orchestrator) processRepositoryCredentials(ctx context.Context, input *
 	return creds, rbfunc, nil
 }
 
-// processRepositoryCredentialsUpdate processes the passed in repository credentials and applies them appropriately.  If the
-// container definition already has credentials set, assume we are updating the credentials in place. In that case, we shouldn't
-// need to set the repository credentials on the input since they are already applied to the container def.  Otherwise, assume
-// the credentials are new (maybe the container def is new too).  In this case, we create the secret and apply the result to the input.
-func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, input *ServiceOrchestrationUpdateInput) (map[string]interface{}, error) {
-	if len(input.Credentials) == 0 {
-		log.Debugf("no private repository credentials passed")
-		return nil, nil
+// processRepositoryCredentialsUpdate processes the repository credentials for the container definitions inside the task definition.
+//
+// If the active container definition HAS repostory credentials set
+// ...AND the input has Credentials defined for the container definition
+// ...AND the input has repository credentials set for the container definition
+// ...THEN update the secret at the (active) ARN in place with the given Credentials and apply to the container definition
+//
+// If the active container definition HAS repository credentials set
+// ...AND the input has Credentials defined for the container definition
+// ...AND the input doesn't have repository credentials set for the container definition
+// ...THEN set the input repository credentials to the ARN for the active container definition repository credentials
+// ...AND update the secret at the ARN in place with the given Credentials
+//
+// If the active container definition HAS repository credentials set
+// ...AND the input doesn't have Credentials defined for the container definition
+// ...AND the input has repository credentials set for the container definition
+// ...THEN override the repository credentials with the ARN of the active repository credentials
+//
+// If the active container definition HAS repository credentials set
+// ...AND the input doesn't have repository credentials set
+// ...AND the input doesn't have Credentials defined for the container definition
+// ...THEN delete the secret at the ARN for the active container definition
+//
+// If the active container definition doesn't exist or doesn't have repository credentials set
+// ...AND the input has Credentials defined for the container definition
+// ...AND the input has repository credentials defined for the container definition
+// ...THEN update the secret in place or fail if it doesn't exist
+// Note: (this case shouldn't happen)
+//
+// If the active container doesn't exist or doesn't have repository credentials set
+// ...AND the input has Credentials defined for the container definition
+// ...THEN create a new secret and apply the resulting ARN to the repository credentials for the input
+//
+// If the active container doesn't exist or doesn't have repository credentials set
+// ...AND the input doesn't have Credentials defined for the container definition
+// ...THEN assume public image, no secrets are created, no repository credentials are applied
+//
+func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, input *ServiceOrchestrationUpdateInput, active *ServiceOrchestrationUpdateOutput) error {
+	if active == nil || active.TaskDefinition == nil || active.TaskDefinition.ContainerDefinitions == nil {
+		return errors.New("cannot process nil active input")
 	}
+
+	activeRepositoryCredentials := containterDefinitionCredsMap(active.TaskDefinition.ContainerDefinitions)
+	log.Debugf("active repository credentials: %+v", activeRepositoryCredentials)
+
+	inputRepositoryCredentials := containterDefinitionCredsMap(input.TaskDefinition.ContainerDefinitions)
+	log.Debugf("input repository credentials: %+v", inputRepositoryCredentials)
+
+	inputCredentials := input.Credentials
+	log.Debugf("input credentials %+v", inputCredentials)
 
 	client := o.SecretsManager
 	creds := make(map[string]interface{}, len(input.Credentials))
 	for _, cd := range input.TaskDefinition.ContainerDefinitions {
 		containerName := aws.StringValue(cd.Name)
-		log.Debugf("processing container definition %s", containerName)
-		if secret, ok := input.Credentials[containerName]; ok {
-			// if the credentials parameter is specified in the container definition, assume we are updating
-			// the credentia in place.  otherwise, assume we are creating a *new* secret/credential
-			if cd.RepositoryCredentials != nil && cd.RepositoryCredentials.CredentialsParameter != nil {
-				secretArn := cd.RepositoryCredentials.CredentialsParameter
-				log.Infof("updating repository credentials secret '%s' for container definition: %s", containerName, aws.StringValue(secretArn))
+		log.Debugf("processing container definition %s repository credentials", containerName)
 
-				secretUpdate := secretsmanager.PutSecretValueInput{
-					ClientRequestToken: secret.ClientRequestToken,
-					SecretId:           secretArn,
-					SecretString:       secret.SecretString,
-				}
+		activeRepositoryCredential, hasActiveRepositoryCredential := activeRepositoryCredentials[containerName]
+		_, hasInputRepositoryCredential := inputRepositoryCredentials[containerName]
+		inputCredential, hasInputCredential := inputCredentials[containerName]
 
-				out, err := client.UpdateSecret(ctx, &secretUpdate)
-				if err != nil {
-					return nil, err
-				}
-
-				log.Debugf("output: %+v", out)
-				creds[containerName] = out
-			} else {
-				log.Infof("creating new repository credentials secret for container definition: %s", containerName)
-
-				smTags := make([]*secretsmanager.Tag, len(input.TaskDefinition.Tags))
-				for i, t := range input.TaskDefinition.Tags {
-					smTags[i] = &secretsmanager.Tag{Key: t.Key, Value: t.Value}
-				}
-				secret.Tags = smTags
-
-				org := ""
-				if o.Org != "" {
-					org = o.Org + "/"
-				}
-
-				cluster := ""
-				if input.Service != nil && input.Service.Cluster != nil {
-					cluster = aws.StringValue(input.Service.Cluster) + "/"
-				}
-
-				secret.Name = aws.String("spinup/" + org + cluster + aws.StringValue(secret.Name))
-
-				out, err := client.CreateSecret(ctx, secret)
-				if err != nil {
-					return nil, err
-				}
-
-				log.Debugf("output: %+v", out)
-
-				log.Infof("setting repository credentials secret for container definition: %s to %s", containerName, aws.StringValue(out.ARN))
-
-				cd.SetRepositoryCredentials(&ecs.RepositoryCredentials{CredentialsParameter: out.ARN})
-				creds[containerName] = out
+		// if there are active repository credentials and no input repository credentials or input credentials,
+		// delete the secret at the active repository credentials
+		if hasActiveRepositoryCredential && !hasInputRepositoryCredential && !hasInputCredential {
+			log.Warnf("active %s container has repository credentials (%s) but updated definition doesn't, deleting credentials", containerName, activeRepositoryCredential)
+			if _, err := client.DeleteSecret(ctx, activeRepositoryCredential, 0); err != nil {
+				return err
 			}
+			// if there are active repository credentials, set the input repository credentials to the active repository credentials
+		} else if hasActiveRepositoryCredential {
+			log.Debugf("overriding input repository credentials with active repository credentials")
+			cd.RepositoryCredentials = &ecs.RepositoryCredentials{
+				CredentialsParameter: aws.String(activeRepositoryCredential),
+			}
+			hasInputRepositoryCredential = true
+		}
+
+		// if there is an input credential and an input repository credential, update the input repository
+		// credential with the active credential.  else if there's an input credential and no input repository
+		// credential, create a new secret
+		if hasInputCredential && hasInputRepositoryCredential {
+			secretArn := cd.RepositoryCredentials.CredentialsParameter
+
+			log.Infof("updating repository credentials secret '%s' for container definition: %s", containerName, aws.StringValue(secretArn))
+
+			secretUpdate := secretsmanager.PutSecretValueInput{
+				ClientRequestToken: inputCredential.ClientRequestToken,
+				SecretId:           secretArn,
+				SecretString:       inputCredential.SecretString,
+			}
+
+			out, err := client.UpdateSecret(ctx, &secretUpdate)
+			if err != nil {
+				return err
+			}
+
+			log.Debugf("update secret output for %s: %+v", containerName, out)
+
+			creds[containerName] = out
+		} else if hasInputCredential {
+			log.Infof("creating new repository credentials secret for container definition: %s", containerName)
+
+			smTags := make([]*secretsmanager.Tag, len(input.TaskDefinition.Tags))
+			for i, t := range input.TaskDefinition.Tags {
+				smTags[i] = &secretsmanager.Tag{Key: t.Key, Value: t.Value}
+			}
+			inputCredential.Tags = smTags
+
+			org := ""
+			if o.Org != "" {
+				org = o.Org + "/"
+			}
+
+			cluster := ""
+			if input.Service != nil && input.Service.Cluster != nil {
+				cluster = aws.StringValue(input.Service.Cluster) + "/"
+			}
+
+			inputCredential.Name = aws.String("spinup/" + org + cluster + aws.StringValue(inputCredential.Name))
+
+			out, err := client.CreateSecret(ctx, inputCredential)
+			if err != nil {
+				return err
+			}
+
+			log.Debugf("create secret output for %s: %+v", containerName, out)
+
+			log.Infof("setting repository credentials secret for container definition: %s to %s", containerName, aws.StringValue(out.ARN))
+
+			cd.RepositoryCredentials = &ecs.RepositoryCredentials{
+				CredentialsParameter: out.ARN,
+			}
+
+			creds[containerName] = out
 		} else {
-			log.Infof("assuming container definition %s references a public image, no credentials included", containerName)
+			log.Infof("nothing to do for %s", containerName)
 		}
 	}
 
-	return creds, nil
+	log.Debugf("processed update of repository credentials: %+v", creds)
+
+	active.Credentials = creds
+
+	return nil
 }
 
 func (o *Orchestrator) processSecretsmanagerTags(tags []*Tag) []*secretsmanager.Tag {
@@ -172,4 +243,16 @@ func (o *Orchestrator) processSecretsmanagerTags(tags []*Tag) []*secretsmanager.
 	log.Debugf("returning processed secretsmanager tag list %+v", smTags)
 
 	return smTags
+}
+
+func containterDefinitionCredsMap(containerDefinitions []*ecs.ContainerDefinition) map[string]string {
+	creds := map[string]string{}
+	for _, cd := range containerDefinitions {
+		if cd.RepositoryCredentials != nil && cd.RepositoryCredentials.CredentialsParameter != nil {
+			name := aws.StringValue(cd.Name)
+			credsArn := aws.StringValue(cd.RepositoryCredentials.CredentialsParameter)
+			creds[name] = credsArn
+		}
+	}
+	return creds
 }

--- a/orchestration/repositorycredentials_test.go
+++ b/orchestration/repositorycredentials_test.go
@@ -2,13 +2,16 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	sm "github.com/YaleSpinup/ecs-api/secretsmanager"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
@@ -146,145 +149,643 @@ func (m *mockSMClient) PutSecretValueWithContext(ctx context.Context, input *sec
 	return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "secret doesn't exist", nil)
 }
 
+func (m *mockSMClient) DeleteSecretWithContext(ctx context.Context, input *secretsmanager.DeleteSecretInput, opts ...request.Option) (*secretsmanager.DeleteSecretOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	if input == nil {
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "invalid input", nil)
+	}
+
+	if input.SecretId == nil {
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "invalid input", nil)
+	}
+
+	for _, secret := range testSecrets {
+		if aws.StringValue(input.SecretId) == secret.ARN {
+			return &secretsmanager.DeleteSecretOutput{
+				ARN:          aws.String(secret.ARN),
+				Name:         aws.String(secret.Name),
+				DeletionDate: aws.Time(time.Now()),
+			}, nil
+		}
+	}
+
+	return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "secret doesn't exist", nil)
+}
+
 func TestProcessRepositoryCredentialsUpdate(t *testing.T) {
 	o := Orchestrator{
 		SecretsManager: sm.SecretsManager{Service: &mockSMClient{t: t}},
 		Org:            "mock",
 	}
 
-	baseTdefInput := ecs.RegisterTaskDefinitionInput{
-		Family: aws.String("tdef1"),
-		Cpu:    aws.String("256"),
-		Memory: aws.String("512"),
-		ContainerDefinitions: []*ecs.ContainerDefinition{
-			{
-				Name:  aws.String("nginx"),
-				Image: aws.String("nginx:alpine"),
-			},
-			{
-				Name:  aws.String("privateapi"),
-				Image: aws.String("privateapi:latest"),
-			},
-		},
+	// test empty input
+	if err := o.processRepositoryCredentialsUpdate(context.TODO(), &ServiceOrchestrationUpdateInput{}, &ServiceOrchestrationUpdateOutput{}); err != nil {
+		if e := err.Error(); e != "cannot process nil active input" {
+			t.Errorf("Expected error 'cannot process nil active input' for empty input, got '%s'", e)
+		}
+	} else {
+		t.Error("expected error for empty input, not nil")
 	}
 
-	var tests = []struct {
-		desc           string
-		tdinput        ecs.RegisterTaskDefinitionInput
-		credentialsMap map[string]*secretsmanager.CreateSecretInput
-		tdresult       ecs.RegisterTaskDefinitionInput
-	}{
-		{
-			desc:           "empty everything",
-			tdinput:        ecs.RegisterTaskDefinitionInput{},
-			credentialsMap: map[string]*secretsmanager.CreateSecretInput{},
-			tdresult:       ecs.RegisterTaskDefinitionInput{},
-		},
-		{
-			desc:           "no creds map",
-			tdinput:        baseTdefInput,
-			credentialsMap: map[string]*secretsmanager.CreateSecretInput{},
-			tdresult:       baseTdefInput,
-		},
-		{
-			desc:    "new creds from map",
-			tdinput: baseTdefInput,
-			credentialsMap: map[string]*secretsmanager.CreateSecretInput{
-				"privateapi": {
-					Name:         aws.String("secret credentials"),
-					SecretString: aws.String("ssssshhhh!"),
-				},
-			},
-			tdresult: ecs.RegisterTaskDefinitionInput{
-				Family: aws.String("tdef1"),
-				Cpu:    aws.String("256"),
-				Memory: aws.String("512"),
+	type test struct {
+		desc     string
+		tdinput  ServiceOrchestrationUpdateInput
+		active   *ecs.TaskDefinition
+		tdresult *ecs.RegisterTaskDefinitionInput
+		inputerr error
+		err      error
+	}
+	tests := []test{}
+
+	// If the active container definition HAS repostory credentials set
+	// ...AND the input has Credentials defined for the container definition
+	// ...AND the input has repository credentials set for the container definition
+	// ...THEN update the secret at the (active) ARN in place with the given Credentials and apply to the container definition
+	tests = append(tests, test{
+		desc: "with active repo creds AND input creds AND input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
 				ContainerDefinitions: []*ecs.ContainerDefinition{
 					{
-						Name:  aws.String("nginx"),
-						Image: aws.String("nginx:alpine"),
+						Name: aws.String("nginx"),
 					},
 					{
-						Name:  aws.String("privateapi"),
-						Image: aws.String("privateapi:latest"),
+						Name: aws.String("privateapi"),
 						RepositoryCredentials: &ecs.RepositoryCredentials{
-							CredentialsParameter: aws.String("arn:spinup/mock/secret credentials"),
+							CredentialsParameter: aws.String("arn:spinup/mock/someOtherCredentials"),
 						},
 					},
 				},
 			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
 		},
-		{
-			desc: "update credentials",
-			tdinput: ecs.RegisterTaskDefinitionInput{
-				Family: aws.String("tdef1"),
-				Cpu:    aws.String("256"),
-				Memory: aws.String("512"),
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
+
+	// If the active container definition HAS repository credentials set
+	// ...AND the input has Credentials defined for the container definition
+	// ...AND the input doesn't have repository credentials set for the container definition
+	// ...THEN set the input repository credentials to the ARN for the active container definition repository credentials
+	// ...AND update the secret at the ARN in place with the given Credentials
+	tests = append(tests, test{
+		desc: "with active repo creds AND input creds AND NO input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
 				ContainerDefinitions: []*ecs.ContainerDefinition{
 					{
-						Name:  aws.String("nginx"),
-						Image: aws.String("nginx:alpine"),
+						Name: aws.String("nginx"),
 					},
 					{
-						Name:  aws.String("privateapi"),
-						Image: aws.String("privateapi:latest"),
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
+
+	// If the active container definition HAS repository credentials set
+	// ...AND the input doesn't have Credentials defined for the container definition
+	// ...AND the input has repository credentials set for the container definition
+	// ...THEN override the repository credentials with the ARN of the active repository credentials
+	tests = append(tests, test{
+		desc: "with active repo creds AND NO input creds AND input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
 						RepositoryCredentials: &ecs.RepositoryCredentials{
 							CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
 						},
 					},
 				},
 			},
-			credentialsMap: map[string]*secretsmanager.CreateSecretInput{
-				"privateapi": {
-					Name:         aws.String("secret credentials"),
-					SecretString: aws.String("ssssshhhh!"),
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
 				},
 			},
-			tdresult: ecs.RegisterTaskDefinitionInput{
-				Family: aws.String("tdef1"),
-				Cpu:    aws.String("256"),
-				Memory: aws.String("512"),
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
+
+	// If the active container definition HAS repository credentials set
+	// ...AND the input doesn't have repository credentials set
+	// ...AND the input doesn't have Credentials defined for the container definition
+	// ...THEN delete the secret at the ARN for the active container definition
+	tests = append(tests, test{
+		desc: "with active repo creds AND NO input creds AND NO input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
 				ContainerDefinitions: []*ecs.ContainerDefinition{
 					{
-						Name:  aws.String("nginx"),
-						Image: aws.String("nginx:alpine"),
+						Name: aws.String("nginx"),
 					},
 					{
-						Name:  aws.String("privateapi"),
-						Image: aws.String("privateapi:latest"),
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+				},
+			},
+		},
+	})
+
+	// If the active container definition doesn't exist or doesn't have repostitory credentials set
+	// ...AND the input has Credentials defined for the container definition
+	// ...AND the input has repository credentials defined for the container definition
+	// ...THEN update the secret in place or fail if it doesn't exist
+	// Note: (this case shouldn't happen)
+	tests = append(tests, test{
+		desc: "without active container def AND input creds AND input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
 						RepositoryCredentials: &ecs.RepositoryCredentials{
 							CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
 						},
 					},
 				},
 			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
 		},
-	}
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
 
-	out, err := o.processRepositoryCredentialsUpdate(context.TODO(), &ServiceOrchestrationUpdateInput{})
-	if err != nil {
-		t.Errorf("expected nil error for processRepositoryCredentialsUpdate, got %s", err)
-	}
+	tests = append(tests, test{
+		desc: "without active repo creds AND input creds AND input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
+						RepositoryCredentials: &ecs.RepositoryCredentials{
+							CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+						},
+					},
+				},
+			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
 
-	if out != nil {
-		t.Errorf("expected nil output for empty repository credentials, got %+v", out)
-	}
+	// If the active container doesn't exist or doesn't have repository credentials set
+	// ...AND the input has Credentials defined for the container definition
+	// ...THEN create a new secret and apply the resulting ARN to the repsitory credentials for the input
+	tests = append(tests, test{
+		desc: "without active container def AND input creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:spinup/mock/secretCredentials"),
+					},
+				},
+			},
+		},
+	})
+
+	tests = append(tests, test{
+		desc: "without active repo creds AND input creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:spinup/mock/secretCredentials"),
+					},
+				},
+			},
+		},
+	})
+
+	// If the active container doesn't exist or doesn't have repository credentials set
+	// ...AND the input doesn't have Credentials defined for the container definition
+	// ...THEN assume public image, no secrets are created, no repository credentials are applied
+	tests = append(tests, test{
+		desc: "without active container def AND NO input creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("notsoprivateapi"),
+					},
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("notsoprivateapi"),
+				},
+			},
+		},
+	})
+
+	tests = append(tests, test{
+		desc: "without active repo creds AND NO input creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("notsoprivateapi"),
+					},
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("notsoprivateapi"),
+				},
+			},
+		},
+		tdresult: &ecs.RegisterTaskDefinitionInput{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("notsoprivateapi"),
+				},
+			},
+		},
+	})
+
+	// error creating secret
+	tests = append(tests, test{
+		inputerr: errors.New("boom"),
+		err:      errors.New("InternalError: failed to create secret (boom)"),
+		desc:     "error creating secret without active container def AND input creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+			},
+		},
+	})
+
+	// error updating secret
+	tests = append(tests, test{
+		inputerr: errors.New("boom"),
+		err:      errors.New("InternalError: failed to update secret (boom)"),
+		desc:     "error updating secret with active repo creds AND input creds AND NO input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+			Credentials: map[string]*secretsmanager.CreateSecretInput{
+				"privateapi": {
+					Name:         aws.String("secretCredentials"),
+					SecretString: aws.String("ssssshhhh!"),
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
+
+	// error deleting secret
+	tests = append(tests, test{
+		inputerr: errors.New("boom"),
+		err:      errors.New("InternalError: failed to delete secret with id arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1 (boom)"),
+		desc:     "error deleting secret with active repo creds AND NO input creds AND NO input repo creds",
+		tdinput: ServiceOrchestrationUpdateInput{
+			TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+					},
+					{
+						Name: aws.String("privateapi"),
+					},
+				},
+			},
+		},
+		active: &ecs.TaskDefinition{
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("nginx"),
+				},
+				{
+					Name: aws.String("privateapi"),
+					RepositoryCredentials: &ecs.RepositoryCredentials{
+						CredentialsParameter: aws.String("arn:aws:secretsmanager:us-east-1:12345678910:secret:test-cred-1"),
+					},
+				},
+			},
+		},
+	})
 
 	for _, test := range tests {
-		t.Logf("testing %s", test.desc)
-
-		tdef := test.tdinput
-		out, err = o.processRepositoryCredentialsUpdate(context.TODO(), &ServiceOrchestrationUpdateInput{
-			TaskDefinition: &tdef,
-			Credentials:    test.credentialsMap,
-		})
-		if err != nil {
-			t.Errorf("expected nil error for processRepositoryCredentialsUpdate, got %s", err)
+		o = Orchestrator{
+			SecretsManager: sm.SecretsManager{Service: &mockSMClient{t: t, err: test.inputerr}},
+			Org:            "mock",
 		}
 
-		t.Log("got processRepositoryCredentials response", out)
-		if !reflect.DeepEqual(tdef, test.tdresult) {
-			t.Fatalf("Expected %+v\nGot %+v", test.tdresult, tdef)
+		t.Logf("testing %s", test.desc)
+
+		err := o.processRepositoryCredentialsUpdate(context.TODO(), &test.tdinput, &ServiceOrchestrationUpdateOutput{
+			TaskDefinition: test.active,
+		})
+
+		if test.err == nil && err != nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if test.err != nil && err == nil {
+			t.Errorf("expected error '%s', got nil", test.err)
+		} else if test.err != nil && err != nil {
+			if test.err.Error() != err.Error() {
+				t.Errorf("expected error '%s', got '%s''", test.err, err)
+			}
+		} else {
+			if !awsutil.DeepEqual(test.tdinput.TaskDefinition.ContainerDefinitions, test.tdresult.ContainerDefinitions) {
+				t.Errorf("expected container defs %s, got %s", awsutil.Prettify(test.tdresult.ContainerDefinitions), awsutil.Prettify(test.tdinput.TaskDefinition.ContainerDefinitions))
+			}
 		}
 	}
 }
@@ -367,4 +868,8 @@ func TestProcessSecretsmanagerTags(t *testing.T) {
 		}
 	}
 
+}
+
+func TestContainerDefinitionCredsMap(t *testing.T) {
+	t.Log("TODO")
 }


### PR DESCRIPTION
This should handle known cases for updating repository credentials in container definitions.

```golang
// If the active container definition HAS repostory credentials set
// ...AND the input has Credentials defined for the container definition
// ...AND the input has repository credentials set for the container definition
// ...THEN update the secret at the (active) ARN in place with the given Credentials and apply to the container definition
//
// If the active container definition HAS repository credentials set
// ...AND the input has Credentials defined for the container definition
// ...AND the input doesn't have repository credentials set for the container definition
// ...THEN set the input repository credentials to the ARN for the active container definition repository credentials
// ...AND update the secret at the ARN in place with the given Credentials
//
// If the active container definition HAS repository credentials set
// ...AND the input doesn't have Credentials defined for the container definition
// ...AND the input has repository credentials set for the container definition
// ...THEN override the repository credentials with the ARN of the active repository credentials
//
// If the active container definition HAS repository credentials set
// ...AND the input doesn't have repository credentials set
// ...AND the input doesn't have Credentials defined for the container definition
// ...THEN delete the secret at the ARN for the active container definition
//
// If the active container definition doesn't exist or doesn't have repository credentials set
// ...AND the input has Credentials defined for the container definition
// ...AND the input has repository credentials defined for the container definition
// ...THEN update the secret in place or fail if it doesn't exist
// Note: (this case shouldn't happen)
//
// If the active container doesn't exist or doesn't have repository credentials set
// ...AND the input has Credentials defined for the container definition
// ...THEN create a new secret and apply the resulting ARN to the repository credentials for the input
//
// If the active container doesn't exist or doesn't have repository credentials set
// ...AND the input doesn't have Credentials defined for the container definition
// ...THEN assume public image, no secrets are created, no repository credentials are applied
//
```