### PR TITLE
Ensure cluster value is set when creating repository credentials

### DIFF
--- a/orchestration/repositorycredentials.go
+++ b/orchestration/repositorycredentials.go
@@ -43,7 +43,9 @@ func (o *Orchestrator) processRepositoryCredentials(ctx context.Context, input *
 			}
 
 			cluster := ""
-			if input.Service != nil && input.Service.Cluster != nil {
+			if input.Cluster != nil && input.Cluster.ClusterName != nil {
+				cluster = aws.StringValue(input.Cluster.ClusterName) + "/"
+			} else if input.Service != nil && input.Service.Cluster != nil {
 				cluster = aws.StringValue(input.Service.Cluster) + "/"
 			}
 
@@ -200,7 +202,9 @@ func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, i
 			}
 
 			cluster := ""
-			if input.Service != nil && input.Service.Cluster != nil {
+			if input.ClusterName != "" {
+				cluster = input.ClusterName + "/"
+			} else if input.Service != nil && input.Service.Cluster != nil {
 				cluster = aws.StringValue(input.Service.Cluster) + "/"
 			}
 


### PR DESCRIPTION
When creating a new service, the service won't exist when we create the repository credentials secret, so we need to reference the cluster input instead.  I made the update logic similar just so it's not even more confusing.