### PR TITLE
Delete default task execution role on recursive delete of service

### DIFF
--- a/ecs/cluster_test.go
+++ b/ecs/cluster_test.go
@@ -183,6 +183,12 @@ func TestDeleteClusterWithRetry(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel2()
 
+	client = ECS{
+		Service: &mockECSClient{
+			t:   t,
+			err: awserr.New(ecs.ErrCodeResourceInUseException, "wont fix", nil),
+		},
+	}
 	cluChan2 := client.DeleteClusterWithRetry(ctx2, aws.String("goodclu"))
 	select {
 	case <-ctx2.Done():
@@ -194,12 +200,7 @@ func TestDeleteClusterWithRetry(t *testing.T) {
 	ctx3, cancel3 := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel3()
 
-	client = ECS{
-		Service: &mockECSClient{
-			t:   t,
-			err: awserr.New(ecs.ErrCodeUpdateInProgressException, "wont fix", nil),
-		},
-	}
+	client = ECS{Service: &mockECSClient{t: t}}
 	cluChan3 := client.DeleteClusterWithRetry(ctx3, aws.String("missing"))
 	select {
 	case <-ctx3.Done():

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -54,7 +54,7 @@ func (e *ECS) ListTags(ctx context.Context, arn string) ([]*ecs.Tag, error) {
 
 	output, err := e.Service.ListTagsForResourceWithContext(ctx, &input)
 	if err != nil {
-		return nil, ErrCode("failed to delete service", err)
+		return nil, ErrCode("failed to list tags for ecs resource", err)
 	}
 
 	log.Debugf("got list of tags for arn '%s': %+v", arn, output)

--- a/iam/role.go
+++ b/iam/role.go
@@ -107,3 +107,39 @@ func (i *IAM) GetRolePolicy(ctx context.Context, role, policy string) (string, e
 
 	return d, nil
 }
+
+func (i *IAM) ListRolePolicies(ctx context.Context, role string) ([]string, error) {
+	if role == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("listing polcies for role %s", role)
+
+	out, err := i.Service.ListRolePoliciesWithContext(ctx, &iam.ListRolePoliciesInput{
+		RoleName: aws.String(role),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to list role polcies", err)
+	}
+
+	log.Debugf("got output listing role policies for '%s': %+v", role, out)
+
+	return aws.StringValueSlice(out.PolicyNames), nil
+}
+
+func (i *IAM) DeleteRolePolicy(ctx context.Context, role, policy string) error {
+	if role == "" || policy == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting policy %s for role %s", policy, role)
+
+	if _, err := i.Service.DeleteRolePolicyWithContext(ctx, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String(role),
+		PolicyName: aws.String(policy),
+	}); err != nil {
+		return ErrCode("failed to delete role policy", err)
+	}
+
+	return nil
+}

--- a/iam/role.go
+++ b/iam/role.go
@@ -108,6 +108,7 @@ func (i *IAM) GetRolePolicy(ctx context.Context, role, policy string) (string, e
 	return d, nil
 }
 
+// ListRolePolicies lists the inline policies for a role
 func (i *IAM) ListRolePolicies(ctx context.Context, role string) ([]string, error) {
 	if role == "" {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
@@ -127,6 +128,7 @@ func (i *IAM) ListRolePolicies(ctx context.Context, role string) ([]string, erro
 	return aws.StringValueSlice(out.PolicyNames), nil
 }
 
+// DeleteRolePolicy deletes an inline policy for a role
 func (i *IAM) DeleteRolePolicy(ctx context.Context, role, policy string) error {
 	if role == "" || policy == "" {
 		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)

--- a/orchestration/iam.go
+++ b/orchestration/iam.go
@@ -189,3 +189,24 @@ func assumeRolePolicy() (string, error) {
 
 	return string(policyDoc), nil
 }
+
+func (o *Orchestrator) deleteDefaultTaskExecutionRole(ctx context.Context, role string) error {
+	policies, err := o.IAM.ListRolePolicies(ctx, role)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range policies {
+		if err := o.IAM.DeleteRolePolicy(ctx, role, p); err != nil {
+			return err
+		}
+	}
+
+	if err := o.IAM.DeleteRole(ctx, &iam.DeleteRoleInput{
+		RoleName: aws.String(role),
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/orchestration/orchestration.go
+++ b/orchestration/orchestration.go
@@ -181,7 +181,8 @@ func (o *Orchestrator) DeleteService(ctx context.Context, input *ServiceDeleteIn
 
 			// if we cleaned up the cluster, we should also cleanup the default task execution role
 			if deletedCluster {
-				if err := o.deleteDefaultTaskExecutionRole(cleanupCtx, "spincool-20210304-ecsTaskExecution"); err != nil {
+				executionRoleName := fmt.Sprintf("%s-ecsTaskExecution", aws.StringValue(input.Cluster))
+				if err := o.deleteDefaultTaskExecutionRole(cleanupCtx, executionRoleName); err != nil {
 					log.Errorf("failed to cleanup default task execution role: %s", err)
 				}
 			}

--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -64,15 +64,12 @@ func (s *ServiceDiscovery) DeleteServiceRegistry(ctx context.Context, serviceArn
 	}
 
 	resource := strings.SplitN(a.Resource, "/", 2)
-	output, err := s.Service.DeleteServiceWithContext(ctx, &servicediscovery.DeleteServiceInput{
+	if _, err := s.Service.DeleteServiceWithContext(ctx, &servicediscovery.DeleteServiceInput{
 		Id: aws.String(resource[1]),
-	})
-
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
-	log.Debugf("output from service discovery service delete:\n%+v", output)
 	return nil
 }
 


### PR DESCRIPTION
* Cleanup default task execution role on recursive delete of service.
* Fix a bug where we always try to delete the cluster.  