### PR TITLE
Create task definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,84 @@
-# ecs-api
+# ECS-API
 
 This API provides simple restful API access to Amazon's ECS Fargate service.
 
-## Endpoints
+## Table of Contents
+
+- [ECS-API](#ecs-api)
+  - [Table of Contents](#table-of-contents)
+  - [Endpoint Summary](#endpoint-summary)
+  - [Definition](#definition)
+    - [Clusters](#clusters)
+    - [Services](#services)
+    - [Tasks](#tasks)
+    - [Task Definitions](#task-definitions)
+    - [SSM Parameters](#ssm-parameters)
+  - [Docker Image verification](#docker-image-verification)
+    - [Check if an image is available](#check-if-an-image-is-available)
+      - [Response](#response)
+  - [Service Orchestration](#service-orchestration)
+    - [Orchestrate a service update](#orchestrate-a-service-update)
+      - [Request](#request)
+        - [Update the tags for an existing service and force a redeployment](#update-the-tags-for-an-existing-service-and-force-a-redeployment)
+        - [Update the task definition and redeploy an existing service](#update-the-task-definition-and-redeploy-an-existing-service)
+        - [Update the service replica count and capacity provider strategy](#update-the-service-replica-count-and-capacity-provider-strategy)
+        - [Add a container definition with credentials](#add-a-container-definition-with-credentials)
+        - [Update a container definitions credentials](#update-a-container-definitions-credentials)
+      - [Response](#response-1)
+    - [Orchestrate a service delete](#orchestrate-a-service-delete)
+      - [Request](#request-1)
+      - [Response](#response-2)
+    - [Get logs for a task](#get-logs-for-a-task)
+      - [Request](#request-2)
+        - [Examples](#examples)
+    - [Create a managed task definition](#create-a-managed-task-definition)
+      - [Request](#request-3)
+      - [Response](#response-3)
+    - [Delete a managed task definition](#delete-a-managed-task-definition)
+      - [Request](#request-4)
+      - [Response](#response-4)
+    - [List managed task definitions in a cluster](#list-managed-task-definitions-in-a-cluster)
+      - [Request](#request-5)
+      - [Response](#response-5)
+    - [Get a managed task definitions in a cluster](#get-a-managed-task-definitions-in-a-cluster)
+      - [Request](#request-6)
+      - [Response](#response-6)
+  - [SSM Parameters](#ssm-parameters-1)
+    - [Create a param](#create-a-param)
+      - [Request](#request-7)
+      - [Response](#response-7)
+    - [List parameters](#list-parameters)
+      - [Response](#response-8)
+    - [Show a parameter](#show-a-parameter)
+      - [Response](#response-9)
+    - [Delete a parameter](#delete-a-parameter)
+      - [Response](#response-10)
+    - [Delete all parameters in a prefix](#delete-all-parameters-in-a-prefix)
+      - [Response](#response-11)
+    - [Update a parameter](#update-a-parameter)
+      - [Request](#request-8)
+      - [Response](#response-12)
+  - [Secrets](#secrets)
+    - [Create a secret](#create-a-secret)
+      - [Request](#request-9)
+      - [Response](#response-13)
+    - [List secrets](#list-secrets)
+      - [Response](#response-14)
+    - [Show a secret](#show-a-secret)
+      - [Response](#response-15)
+    - [Delete a secret](#delete-a-secret)
+      - [Response](#response-16)
+    - [Update a secret](#update-a-secret)
+      - [Request](#request-10)
+      - [Response](#response-17)
+    - [List load balancers (target groups) for a space](#list-load-balancers-target-groups-for-a-space)
+      - [Response](#response-18)
+  - [Development](#development)
+  - [Author](#author)
+  - [License](#license)
+
+
+## Endpoint Summary
 
 ```text
 GET /v1/ecs/ping
@@ -25,6 +101,12 @@ GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="{task}"&c
 // Tasks handlers
 GET /v1/ecs/{account}/clusters/{cluster}/tasks/{task}
 
+// TaskDef handlers
+POST /v1/ecs/{account}/taskdefs
+GET /v1/ecs/{account}/clusters/{cluster}/taskdefs
+DELETE /v1/ecs/{account}/clusters/{cluster}/taskdefs/{taskdef}
+GET /v1/ecs/{account}/clusters/{cluster}/taskdefs/{taskdef}
+
 // Secrets handlers
 GET /v1/ecs/{account}/secrets
 POST /v1/ecs/{account}/secrets
@@ -43,6 +125,28 @@ PUT /v1/ecs//{account}/params/{prefix}/{param}
 // Load balancer handlers
 GET /v1/ecs/{account}/lbs?space={space}
 ```
+
+## Definition
+
+### Clusters
+
+`Clusters` provide groupings of containers.  Clusters control the default capacity provider strategy which determines when to leverage spot and on demand containers.
+
+### Services
+
+`Services` are long lived/scalable tasks launched based on a task definition.  Services can be comprised of multiple `containers` (because multiple containers can be defined in a task definition!).  AWS will restart containers belonging to services when they exit or die.  `Services` can be scaled and can be associated with load balancers.  Tasks that make up a service can have IP addresses, but those addresses change when tasks are restarted.
+
+### Tasks
+
+`Tasks`, in contrast to `Services`, should be considered short lived.  They will not automatically be restarted or scaled by AWS and cannot be associated with a load balancer.  `Tasks`, as with `services`, can be made up of multiple containers.  Tasks can have IP addresses, but those addresses change when tasks are restarted.
+
+### Task Definitions
+
+An ECS `Task definition` describes a set of containers used in a `service` or `task`.  The resources managed by the `taskdefs` endpoints in this API manage task definition lifecycle in addition to dependent resources for a task (clusters, tags, etc).
+
+### SSM Parameters
+
+`Parameters` store string data in AWS SSM parameter store. By default, parameters are encrypted (in AWS) by the `defaultKmsKeyId` given for each `account`.
 
 ## Docker Image verification
 
@@ -186,9 +290,9 @@ Service update orchestration currently supports:
 * updating the task definition and redeploying
 * updating the service parameters (like replica count, or capacity provider strategy)
 
-PUT `/v1/ecs/{account}/clusters/{cluster}/services/{service}`
-
 #### Request
+
+PUT `/v1/ecs/{account}/clusters/{cluster}/services/{service}`
 
 ##### Update the tags for an existing service and force a redeployment
 
@@ -335,6 +439,8 @@ TODO
 
 Service delete orchestration supports deleting a service or recursively deleting a service and its dependencies.
 
+#### Request
+
 DELETE `/v1/ecs/{account}/clusters/{cluster}/services/{service}[?recursive=true]`
 
 #### Response
@@ -352,7 +458,9 @@ TODO
 | **404 Not Found**             | account, cluster or service wasn't found |
 | **500 Internal Server Error** | a server error occurred                  |
 
-#### Get logs for a task
+### Get logs for a task
+
+#### Request
 
 GET `/v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"....`
 
@@ -368,35 +476,149 @@ GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&cont
 GET /v1/ecs/{account}/clusters/{cluster}/services/{service}/logs?task="foo"&container="bar"&start="1583504305223"&end="1583527860973"&limit="30"&seq="f/35313851203912372440587619261645128276299525300062978048"
 ```
 
-## Adhoc Requests
+### Create a managed task definition
 
-### Clusters
+The ECS-API allows for creating a task definition that fits into the service paradigm for Spinup.  This will create a runnable task definition as well as any dependent services such as clusters, secrets and tags.
 
-Clusters provide groupings of containers.  With `FARGATE`, clusters are simply created with a name parameter.
+#### Request
 
-### Services
+POST /v1/ecs/{account}/taskdefs
 
-`Services` are long lived/scalable tasks launched based on a task definition.  Services can be comprised of multiple `containers` (because multiple containers can be defined in a task definition!).  AWS will restart containers belonging to services when they exit or die.  `Services` can be scaled and can be associated with load balancers.  Tasks that make up a service can have IP addresses, but those addresses change when tasks are restarted.
+```json
+{
+    "cluster": {
+        "clustername": "myclu"
+    },
+    "taskdefinition": {
+        "family": "supercool-service",
+        "cpu": "256",
+        "memory": "512",
+        "containerdefinitions": [
+            {
+                "name": "nginx",
+                "image": "nginx:alpine",
+                "portmappings": [{"ContainerPort": 80}]
+            },
+            {
+                "name": "api",
+                "image": "yaleits/testapi",
+                "portmappings": [{"ContainerPort": 8080}]
+            }
+        ]
+        },
+    "credentials": {
+        "api": {
+            "SecretString": "{\"username\" : \"myorguser\",\"password\" : \"new-super-sekret-password-string\"}",
+        }
+    },
+    "tags": [
+        {
+            "Key": "Application",
+            "Value": "myclu"
+        },
+        {
+            "Key": "COA",
+            "Value": "Bill.Me.Please.COA"
+        }
+    ]
+}
+```
 
-### Tasks
+#### Response
 
-`Tasks`, in contrast to `Services`, should be considered short lived.  They will not automatically be restarted or scaled by AWS and cannot be associated with a load balancer.  `Tasks`, as with `services`, can be made up of multiple containers.  Tasks can have IP addresses, but those addresses change when tasks are restarted.
+```json
+TODO
+```
 
-### Task Definitions
+| Response Code                 | Definition                               |
+| ----------------------------- | -----------------------------------------|
+| **200 OK**                    | okay                                     |
+| **400 Bad Request**           | badly formed request                     |
+| **404 Not Found**             | account, cluster or taskdef wasn't found |
+| **500 Internal Server Error** | a server error occurred                  |
 
-`Task definitions` describe a set of containers used in a `service` or `task`.
+### Delete a managed task definition
 
-### SSM Parameters
+#### Request
 
-`Parameters` store string data in AWS SSM parameter store. By default, parameters are encrypted (in AWS) by the `defaultKmsKeyId` given for each `account`.
+DELETE /v1/ecs/{account}/cluster/{cluster}/taskdefs/{taskdef}
 
-#### Create a param
+#### Response
+
+The response is the service body.
+
+```json
+{
+    "Cluster": "myclu",
+    "TaskDefinition": "supercool-service"
+}
+```
+
+| Response Code                 | Definition                               |
+| ----------------------------- | -----------------------------------------|
+| **200 OK**                    | okay                                     |
+| **400 Bad Request**           | badly formed request                     |
+| **404 Not Found**             | account, cluster or taskdef wasn't found |
+| **500 Internal Server Error** | a server error occurred                  |
+
+### List managed task definitions in a cluster
+
+List returns an array of task definition families - there may be multiple revisions of a task definition.
+
+#### Request
+
+GET /v1/ecs/{account}/cluster/{cluster}/taskdefs
+
+#### Response
+
+The response is the service body.
+
+```json
+[
+    "supercool-service"
+]
+```
+
+| Response Code                 | Definition                               |
+| ----------------------------- | -----------------------------------------|
+| **200 OK**                    | okay                                     |
+| **400 Bad Request**           | badly formed request                     |
+| **404 Not Found**             | account, cluster or taskdef wasn't found |
+| **500 Internal Server Error** | a server error occurred                  |
+
+### Get a managed task definitions in a cluster
+
+Gets the details about a managed task definition
+
+#### Request
+
+GET /v1/ecs/{account}/cluster/{cluster}/taskdefs/{taskdef}
+
+#### Response
+
+The response is the service body.
+
+```json
+TODO
+```
+
+| Response Code                 | Definition                               |
+| ----------------------------- | -----------------------------------------|
+| **200 OK**                    | okay                                     |
+| **400 Bad Request**           | badly formed request                     |
+| **404 Not Found**             | account, cluster or taskdef wasn't found |
+| **500 Internal Server Error** | a server error occurred                  |
+
+
+## SSM Parameters
+
+### Create a param
 
 Parameters are automatically creating in the `org` path.  A `prefix` should be specified in the `Name`.
 
 POST `/v1/ecs/{account}/params/{prefix}`
 
-##### Request
+#### Request
 
 [PutParameterInput](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#PutParameterInput)
 
@@ -412,7 +634,7 @@ POST `/v1/ecs/{account}/params/{prefix}`
 }
 ```
 
-##### Response
+#### Response
 
 ```json
 {
@@ -428,13 +650,13 @@ POST `/v1/ecs/{account}/params/{prefix}`
 | **404 Not Found**             | account wasn't found                  |
 | **500 Internal Server Error** | a server error occurred               |
 
-#### List parameters
+### List parameters
 
 Listing parameters is limited to the parameters that belong to the *org*. A `prefix` is also required.
 
 GET `/v1/ecs/{account}/params/{prefix}`
 
-##### Response
+#### Response
 
 ```json
 [
@@ -451,13 +673,13 @@ GET `/v1/ecs/{account}/params/{prefix}`
 | **404 Not Found**             | account or prefix wasn't found        |
 | **500 Internal Server Error** | a server error occurred               |
 
-#### Show a parameter
+### Show a parameter
 
 Pass the parameter `prefix` and `param` to get the metadata about a secret.  The `org` will automatically be prepended.
 
 GET `/v1/ecs/{account}/params/{prefix}/{param}`
 
-##### Response
+#### Response
 
 ```json
 {
@@ -492,11 +714,11 @@ GET `/v1/ecs/{account}/params/{prefix}/{param}`
 | **404 Not Found**             | account, param or prefix wasn't found |
 | **500 Internal Server Error** | a server error occurred               |
 
-#### Delete a parameter
+### Delete a parameter
 
 DELETE `/v1/ecs/{account}/params/{prefix}/{param}`
 
-##### Response
+#### Response
 
 ```json
 {"OK"}
@@ -509,11 +731,11 @@ DELETE `/v1/ecs/{account}/params/{prefix}/{param}`
 | **404 Not Found**             | account, param or prefix wasn't found |
 | **500 Internal Server Error** | a server error occurred               |
 
-#### Delete all parameters in a prefix
+### Delete all parameters in a prefix
 
 DELETE `/v1/ecs/{account}/params/{prefix}`
 
-##### Response
+#### Response
 
 ```json
 {
@@ -529,13 +751,13 @@ DELETE `/v1/ecs/{account}/params/{prefix}`
 | **404 Not Found**             | account or prefix wasn't found        |
 | **500 Internal Server Error** | a server error occurred               |
 
-#### Update a parameter
+### Update a parameter
 
 Update the tags and/or value of a parameter.  Pass the `prefix` and the `param`.
 
 PUT `/v1/ecs/{account}/params/{prefix}/{param}`
 
-##### Request
+#### Request
 
 ```json
 {
@@ -547,7 +769,7 @@ PUT `/v1/ecs/{account}/params/{prefix}/{param}`
 }
 ```
 
-##### Response
+#### Response
 
 ```json
 {"OK"}
@@ -560,15 +782,15 @@ PUT `/v1/ecs/{account}/params/{prefix}/{param}`
 | **404 Not Found**             | account, param or prefix wasn't found |
 | **500 Internal Server Error** | a server error occurred               |
 
-### Secrets
+## Secrets
 
 `Secrets` store binary or string data in AWS secrets manager. By default, secrets are encrypted (in AWS) by the `defaultKmsKeyId` given for each `account`.
 
-#### Create a secret
+### Create a secret
 
 POST `/v1/ecs/{account}/secrets`
 
-##### Request
+#### Request
 
 ```json
 {
@@ -577,7 +799,7 @@ POST `/v1/ecs/{account}/secrets`
 }
 ```
 
-##### Response
+#### Response
 
 ```json
 {
@@ -593,14 +815,14 @@ POST `/v1/ecs/{account}/secrets`
 | **400 Bad Request**           | badly formed request            |
 | **500 Internal Server Error** | a server error occurred         |
 
-#### List secrets
+### List secrets
 
 Listing secrets is limited to the secrets that belong to the *org*. Optionally pass `key=value` pairs
 to filter on secret tags.
 
 GET `/v1/ecs/{account}/secrets[?key1=value1[&key2=value2&key3=value3]]`
 
-##### Response
+#### Response
 
 ```json
 [
@@ -615,13 +837,13 @@ GET `/v1/ecs/{account}/secrets[?key1=value1[&key2=value2&key3=value3]]`
 | **400 Bad Request**           | badly formed request            |
 | **500 Internal Server Error** | a server error occurred         |
 
-#### Show a secret
+### Show a secret
 
 Pass the secret id to get the metadata about a secret.
 
 GET `/v1/ecs/{account}/secret/{secret}`
 
-##### Response
+#### Response
 
 ```json
 {
@@ -657,14 +879,14 @@ GET `/v1/ecs/{account}/secret/{secret}`
 | **404 Not Found**             | secret wasn't found in the org  |
 | **500 Internal Server Error** | a server error occurred         |
 
-#### Delete a secret
+### Delete a secret
 
 Pass the secret id and an options `window` parameter (in days).  A parameter of `0` will cause the secret
 to be deleted immediately.  Otherwise the grace period must be between `7` and `30`.
 
 DELETE `/v1/ecs/{account}/secret/{secret}[?window=[0|7-30]]`
 
-##### Response
+#### Response
 
 ```json
 {
@@ -681,14 +903,14 @@ DELETE `/v1/ecs/{account}/secret/{secret}[?window=[0|7-30]]`
 | **404 Not Found**             | secret wasn't found in the org  |
 | **500 Internal Server Error** | a server error occurred         |
 
-#### Update a secret
+### Update a secret
 
 Pass the secret id, the new secret string value and/or the list of tags to update. Currently,
 updating binary secrets is not supported, nor is setting the secret version.
 
 PUT `/v1/ecs/{account}/secrets/{secret}`
 
-##### Request
+#### Request
 
 ```json
 {
@@ -702,7 +924,7 @@ PUT `/v1/ecs/{account}/secrets/{secret}`
 }
 ```
 
-##### Response
+#### Response
 
 When only updating tags, you will get an empty response on success. When updating a secret:
 
@@ -721,11 +943,11 @@ When only updating tags, you will get an empty response on success. When updatin
 | **404 Not Found**             | secret wasn't found in the org  |
 | **500 Internal Server Error** | a server error occurred         |
 
-#### List load balancers (target groups) for a space
+### List load balancers (target groups) for a space
 
 GET `/v1/ecs/{account}/lbs?space={space}`
 
-##### Response
+#### Response
 
 ```json
 {
@@ -742,13 +964,13 @@ GET `/v1/ecs/{account}/lbs?space={space}`
 
 ## Development
 
-* Install Go v1.11 or newer
-* Enable Go modules: `export GO111MODULE=on`
-* Create a config: `cp -p config/config.example.json config/config.json`
-* Edit `config.json` and update the parameters
-* Run `go run .` to start the app locally while developing
-* Run `go test ./...` to run all tests
-* Run `go build ./...` to build the binary
+- Install Go v1.11 or newer
+- Enable Go modules: `export GO111MODULE=on`
+- Create a config: `cp -p config/config.example.json config/config.json`
+- Edit `config.json` and update the parameters
+- Run `go run .` to start the app locally while developing
+- Run `go test ./...` to run all tests
+- Run `go build ./...` to build the binary
 
 ## Author
 

--- a/api/handlers_services.go
+++ b/api/handlers_services.go
@@ -77,16 +77,6 @@ func (s *server) ServiceDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	cluster := vars["cluster"]
 	service := vars["service"]
 
-	if cluster == "" {
-		handleError(w, apierror.New(apierror.ErrNotFound, "cluster cannot be empty", nil))
-		return
-	}
-
-	if service == "" {
-		handleError(w, apierror.New(apierror.ErrNotFound, "service cannot be empty", nil))
-		return
-	}
-
 	// Check for the all query param
 	recursive := false
 	b, err := strconv.ParseBool(r.URL.Query().Get("recursive"))
@@ -249,7 +239,7 @@ func (s *server) ServiceShowHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		tdOutput, err := ecsService.GetTaskDefinition(r.Context(), serviceOutput.TaskDefinition)
+		tdOutput, _, err := ecsService.GetTaskDefinition(r.Context(), serviceOutput.TaskDefinition)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -320,6 +310,12 @@ func (s server) newOrchestrator(account string) (*orchestration.Orchestrator, er
 		return nil, apierror.New(apierror.ErrNotFound, msg, nil)
 	}
 
+	rgTaggingAPIService, ok := s.rgTaggingAPIServices[account]
+	if !ok {
+		msg := fmt.Sprintf("resourcegroups tagging service not found for account: %s", account)
+		return nil, apierror.New(apierror.ErrNotFound, msg, nil)
+	}
+
 	sdService, ok := s.sdServices[account]
 	if !ok {
 		msg := fmt.Sprintf("service discovery service not found for account: %s", account)
@@ -333,16 +329,17 @@ func (s server) newOrchestrator(account string) (*orchestration.Orchestrator, er
 	}
 
 	return &orchestration.Orchestrator{
-		CloudWatchLogs:        cwlService,
-		ECS:                   ecsService,
-		IAM:                   iamService,
-		SecretsManager:        smService,
-		ServiceDiscovery:      sdService,
-		DefaultSecurityGroups: ecsService.DefaultSgs,
-		DefaultSubnets:        ecsService.DefaultSubnets,
-		DefaultPublic:         "DISABLED",
-		Token:                 uuid.NewV4().String(),
-		Org:                   s.org,
+		CloudWatchLogs:           cwlService,
+		ECS:                      ecsService,
+		IAM:                      iamService,
+		ResourceGroupsTaggingAPI: rgTaggingAPIService,
+		SecretsManager:           smService,
+		ServiceDiscovery:         sdService,
+		DefaultSecurityGroups:    ecsService.DefaultSgs,
+		DefaultSubnets:           ecsService.DefaultSubnets,
+		DefaultPublic:            "DISABLED",
+		Token:                    uuid.NewV4().String(),
+		Org:                      s.org,
 	}, nil
 }
 

--- a/api/handlers_services.go
+++ b/api/handlers_services.go
@@ -36,7 +36,8 @@ func (s *server) ServiceCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, _ := ioutil.ReadAll(r.Body)
-	log.Debugf("new service orchestration request body: %s", body)
+
+	log.Debugf("new service orchestration request body:\n%s", body)
 
 	var req orchestration.ServiceOrchestrationInput
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {

--- a/api/handlers_taskdef.go
+++ b/api/handlers_taskdef.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/YaleSpinup/ecs-api/orchestration"
+
+	"github.com/gorilla/mux"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TaskDefCreateHandler creates the task definition and ensures all of the required
+// services exist for running it
+func (s *server) TaskDefCreateHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+
+	orchestrator, err := s.newOrchestrator(account)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+
+	log.Debugf("new taskdef orchestration request body:\n%s", body)
+
+	var req orchestration.TaskDefCreateOrchestrationInput
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
+		log.Error("cannot Decode body into create taskdef input")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	log.Debugf("decoded request into taskdef orchestration request:\n %+v", req)
+
+	output, err := orchestrator.CreateTaskDef(r.Context(), &req)
+	if err != nil {
+		log.Errorf("error in creating taskdef orchestration: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}

--- a/api/handlers_taskdef.go
+++ b/api/handlers_taskdef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 
 	"github.com/YaleSpinup/ecs-api/orchestration"
 
@@ -43,6 +44,121 @@ func (s *server) TaskDefCreateHandler(w http.ResponseWriter, r *http.Request) {
 	output, err := orchestrator.CreateTaskDef(r.Context(), &req)
 	if err != nil {
 		log.Errorf("error in creating taskdef orchestration: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+func (s *server) TaskDefDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+	taskdef := vars["taskdef"]
+
+	// Check for the all query param
+	recursive := false
+	b, err := strconv.ParseBool(r.URL.Query().Get("recursive"))
+	if err == nil {
+		recursive = b
+	}
+
+	log.Debugf("request to delete account %s cluster %s taskdef %s (recursive: %t)", account, cluster, taskdef, recursive)
+
+	orchestrator, err := s.newOrchestrator(account)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	output, err := orchestrator.DeleteTaskDef(r.Context(), &orchestration.TaskDefDeleteInput{
+		Cluster:        cluster,
+		TaskDefinition: taskdef,
+		Recursive:      recursive,
+	})
+	if err != nil {
+		log.Errorf("error in taskdef delete orchestration: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+func (s *server) TaskDefListHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+
+	log.Debugf("listing task definitions in cluster %s", cluster)
+
+	orchestrator, err := s.newOrchestrator(account)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	output, err := orchestrator.ListTaskDefs(r.Context(), cluster)
+	if err != nil {
+		log.Errorf("error in taskdef list orchestration: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+func (s *server) TaskDefShowHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+	taskdef := vars["taskdef"]
+
+	log.Debugf("showing taskdef %s/%s/%s", account, cluster, taskdef)
+
+	orchestrator, err := s.newOrchestrator(account)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	output, err := orchestrator.GetTaskDef(r.Context(), cluster, taskdef)
+	if err != nil {
+		log.Errorf("error in taskdef get orchestration: %s", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return

--- a/api/routes.go
+++ b/api/routes.go
@@ -32,6 +32,9 @@ func (s *server) routes() {
 
 	// TaskDef handlers
 	api.HandleFunc("/{account}/taskdefs", s.TaskDefCreateHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs", s.TaskDefListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefShowHandler).Methods(http.MethodGet)
 
 	// Secrets handlers
 	api.HandleFunc("/{account}/secrets", s.SecretListHandler).Methods(http.MethodGet)

--- a/api/routes.go
+++ b/api/routes.go
@@ -30,6 +30,9 @@ func (s *server) routes() {
 	// Tasks handlers
 	api.HandleFunc("/{account}/clusters/{cluster}/tasks/{task}", s.TaskShowHandler).Methods(http.MethodGet)
 
+	// TaskDef handlers
+	api.HandleFunc("/{account}/taskdefs", s.TaskDefCreateHandler).Methods(http.MethodPost)
+
 	// Secrets handlers
 	api.HandleFunc("/{account}/secrets", s.SecretListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/secrets", s.SecretCreateHandler).Methods(http.MethodPost)

--- a/ecs/taskdefinition.go
+++ b/ecs/taskdefinition.go
@@ -46,24 +46,25 @@ func (e *ECS) DeleteTaskDefinition(ctx context.Context, taskdefinition *string) 
 }
 
 // GetTaskDefinition gets a task definition with context by name
-func (e *ECS) GetTaskDefinition(ctx context.Context, taskdefinition *string) (*ecs.TaskDefinition, error) {
+func (e *ECS) GetTaskDefinition(ctx context.Context, taskdefinition *string) (*ecs.TaskDefinition, []*ecs.Tag, error) {
 	if aws.StringValue(taskdefinition) == "" {
-		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+		return nil, nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
 	log.Infof("getting details about task definition '%s'", aws.StringValue(taskdefinition))
 
 	output, err := e.Service.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
+		Include:        aws.StringSlice([]string{"TAGS"}),
 		TaskDefinition: taskdefinition,
 	})
 
 	if err != nil {
-		return nil, ErrCode("failed to get task definition", err)
+		return nil, nil, ErrCode("failed to get task definition", err)
 	}
 
 	log.Debugf("got output from DescribeTaskDefinition: %+v", output)
 
-	return output.TaskDefinition, err
+	return output.TaskDefinition, output.Tags, err
 }
 
 // ListTaskDefinitionRevisions lists all of the task definition [revisions] in a family

--- a/ecs/taskdefinition_test.go
+++ b/ecs/taskdefinition_test.go
@@ -165,7 +165,7 @@ func TestCreateTaskDefinition(t *testing.T) {
 
 func TestGetTaskDefinition(t *testing.T) {
 	client := ECS{Service: &mockECSClient{t: t}}
-	td, err := client.GetTaskDefinition(context.TODO(), goodTd1.TaskDefinitionArn)
+	td, _, err := client.GetTaskDefinition(context.TODO(), goodTd1.TaskDefinitionArn)
 	if err != nil {
 		t.Fatal("expected no error from describe task definition, got:", err)
 	}
@@ -175,24 +175,24 @@ func TestGetTaskDefinition(t *testing.T) {
 	}
 
 	// test nil task definition
-	_, err = client.GetTaskDefinition(context.TODO(), nil)
+	_, _, err = client.GetTaskDefinition(context.TODO(), nil)
 	if err == nil {
 		t.Fatal("expected error from create task definition, got nil")
 	}
 
 	// test empty task definition
-	_, err = client.GetTaskDefinition(context.TODO(), aws.String(""))
+	_, _, err = client.GetTaskDefinition(context.TODO(), aws.String(""))
 	if err == nil {
 		t.Fatal("expected error from create task definition, got nil")
 	}
 
-	_, err = client.GetTaskDefinition(context.TODO(), aws.String("somenotfoundtd"))
+	_, _, err = client.GetTaskDefinition(context.TODO(), aws.String("somenotfoundtd"))
 	if err == nil {
 		t.Fatal("expected error from GetTaskDefinition, got:", err)
 	}
 
 	// test an error task definition
-	td, err = client.GetTaskDefinition(context.TODO(), aws.String("badtd"))
+	td, _, err = client.GetTaskDefinition(context.TODO(), aws.String("badtd"))
 	if err == nil {
 		t.Fatal("expected error from create task definition, got", err, td)
 	}

--- a/iam/role_test.go
+++ b/iam/role_test.go
@@ -160,6 +160,13 @@ func (m *mockIAMClient) DeleteRolePolicyWithContext(ctx context.Context, input *
 	return &iam.DeleteRolePolicyOutput{}, nil
 }
 
+func (m *mockIAMClient) TagRoleWithContext(ctx context.Context, input *iam.TagRoleInput, opts ...request.Option) (*iam.TagRoleOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.TagRoleOutput{}, nil
+}
+
 func TestCreateRole(t *testing.T) {
 	i := IAM{
 		Service:         newMockIAMClient(t, nil),
@@ -983,6 +990,37 @@ func TestIAM_DeleteRolePolicy(t *testing.T) {
 			}
 			if err := i.DeleteRolePolicy(tt.args.ctx, tt.args.role, tt.args.policy); (err != nil) != tt.wantErr {
 				t.Errorf("IAM.DeleteRolePolicy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIAM_TagRole(t *testing.T) {
+	type fields struct {
+		Service         iamiface.IAMAPI
+		DefaultKmsKeyID string
+	}
+	type args struct {
+		ctx  context.Context
+		role string
+		tags []*iam.Tag
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &IAM{
+				Service:         tt.fields.Service,
+				DefaultKmsKeyID: tt.fields.DefaultKmsKeyID,
+			}
+			if err := i.TagRole(tt.args.ctx, tt.args.role, tt.args.tags); (err != nil) != tt.wantErr {
+				t.Errorf("IAM.TagRole() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -149,7 +149,7 @@ func (m *mockECSClient) DescribeClustersWithContext(ctx aws.Context, input *ecs.
 }
 
 func TestProcessCluster(t *testing.T) {
-	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil)
+	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil, nil)
 
 	if _, _, err := orchestrator.processServiceCluster(context.TODO(), &ServiceOrchestrationInput{}); err == nil {
 		t.Error("expected error for missing cluster, got nil")
@@ -182,7 +182,7 @@ func TestProcessCluster(t *testing.T) {
 	}
 
 	err := awserr.New(ecs.ErrCodeUpdateInProgressException, "broke", nil)
-	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil)
+	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil, nil)
 
 	input := ServiceOrchestrationInput{
 		Service: &ecs.CreateServiceInput{},
@@ -196,7 +196,7 @@ func TestProcessCluster(t *testing.T) {
 }
 
 func TestProcessTaskCluster(t *testing.T) {
-	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil)
+	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil, nil)
 
 	if _, _, err := orchestrator.processTaskCluster(context.TODO(), &TaskDefCreateOrchestrationInput{}); err == nil {
 		t.Error("expected error for missing cluster, got nil")
@@ -224,7 +224,7 @@ func TestProcessTaskCluster(t *testing.T) {
 	}
 
 	err := awserr.New(ecs.ErrCodeUpdateInProgressException, "broke", nil)
-	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil)
+	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil, nil)
 
 	input := TaskDefCreateOrchestrationInput{
 		TaskDefinition: &ecs.RegisterTaskDefinitionInput{},

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -151,7 +151,7 @@ func (m *mockECSClient) DescribeClustersWithContext(ctx aws.Context, input *ecs.
 func TestProcessCluster(t *testing.T) {
 	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil)
 
-	if _, _, err := orchestrator.processCluster(context.TODO(), &ServiceOrchestrationInput{}); err == nil {
+	if _, _, err := orchestrator.processServiceCluster(context.TODO(), &ServiceOrchestrationInput{}); err == nil {
 		t.Error("expected error for missing cluster, got nil")
 	}
 
@@ -163,7 +163,7 @@ func TestProcessCluster(t *testing.T) {
 			},
 		}
 
-		out, _, err := orchestrator.processCluster(context.TODO(), &input)
+		out, _, err := orchestrator.processServiceCluster(context.TODO(), &input)
 		if err != nil {
 			t.Errorf("expected nil error, got %s", err)
 		}
@@ -186,7 +186,7 @@ func TestProcessCluster(t *testing.T) {
 			},
 		}
 
-		out, _, err := orchestrator.processCluster(context.TODO(), &input)
+		out, _, err := orchestrator.processServiceCluster(context.TODO(), &input)
 		if err != nil {
 			t.Errorf("expected nil error, got %s", err)
 		}
@@ -205,7 +205,7 @@ func TestProcessCluster(t *testing.T) {
 			Cluster: aws.String("cluster0"),
 		},
 	}
-	if _, _, err := orchestrator.processCluster(context.TODO(), &input); err == nil {
+	if _, _, err := orchestrator.processServiceCluster(context.TODO(), &input); err == nil {
 		t.Error("expected error, got nil")
 	}
 
@@ -215,7 +215,7 @@ func TestProcessCluster(t *testing.T) {
 			ClusterName: aws.String("cluster0"),
 		},
 	}
-	if _, _, err := orchestrator.processCluster(context.TODO(), &input); err == nil {
+	if _, _, err := orchestrator.processServiceCluster(context.TODO(), &input); err == nil {
 		t.Error("expected error, got nil")
 	}
 }

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -158,26 +158,6 @@ func TestProcessCluster(t *testing.T) {
 	for _, c := range testClusters {
 		// test including cluster in service
 		input := ServiceOrchestrationInput{
-			Service: &ecs.CreateServiceInput{
-				Cluster: c.ClusterName,
-			},
-		}
-
-		out, _, err := orchestrator.processServiceCluster(context.TODO(), &input)
-		if err != nil {
-			t.Errorf("expected nil error, got %s", err)
-		}
-		t.Logf("got output from process cluster %+v", out)
-
-		if !reflect.DeepEqual(out, c) {
-			t.Errorf("expected %+v, got %+v", c, out)
-		}
-
-	}
-
-	for _, c := range testClusters {
-		// test including cluster in service
-		input := ServiceOrchestrationInput{
 			Service: &ecs.CreateServiceInput{},
 			Cluster: &ecs.CreateClusterInput{
 				CapacityProviders: c.CapacityProviders,
@@ -195,27 +175,64 @@ func TestProcessCluster(t *testing.T) {
 		if !reflect.DeepEqual(out, c) {
 			t.Errorf("expected %+v, got %+v", c, out)
 		}
+
+		if aws.StringValue(input.Service.Cluster) != aws.StringValue(out.ClusterName) {
+			t.Errorf("expected input service cluster to be %s, got %s", aws.StringValue(input.Service.Cluster), aws.StringValue(out.ClusterName))
+		}
 	}
 
 	err := awserr.New(ecs.ErrCodeUpdateInProgressException, "broke", nil)
 	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil)
 
 	input := ServiceOrchestrationInput{
-		Service: &ecs.CreateServiceInput{
-			Cluster: aws.String("cluster0"),
-		},
-	}
-	if _, _, err := orchestrator.processServiceCluster(context.TODO(), &input); err == nil {
-		t.Error("expected error, got nil")
-	}
-
-	input = ServiceOrchestrationInput{
 		Service: &ecs.CreateServiceInput{},
 		Cluster: &ecs.CreateClusterInput{
 			ClusterName: aws.String("cluster0"),
 		},
 	}
 	if _, _, err := orchestrator.processServiceCluster(context.TODO(), &input); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestProcessTaskCluster(t *testing.T) {
+	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil)
+
+	if _, _, err := orchestrator.processTaskCluster(context.TODO(), &TaskDefCreateOrchestrationInput{}); err == nil {
+		t.Error("expected error for missing cluster, got nil")
+	}
+
+	for _, c := range testClusters {
+		// test including cluster in service
+		input := TaskDefCreateOrchestrationInput{
+			Cluster: &ecs.CreateClusterInput{
+				CapacityProviders: c.CapacityProviders,
+				ClusterName:       c.ClusterName,
+				Tags:              c.Tags,
+			},
+		}
+
+		out, _, err := orchestrator.processTaskCluster(context.TODO(), &input)
+		if err != nil {
+			t.Errorf("expected nil error, got %s", err)
+		}
+		t.Logf("got output from process task cluster %+v", out)
+
+		if !reflect.DeepEqual(out, c) {
+			t.Errorf("expected %+v, got %+v", c, out)
+		}
+	}
+
+	err := awserr.New(ecs.ErrCodeUpdateInProgressException, "broke", nil)
+	orchestrator = newMockOrchestrator(t, "myorg", nil, err, nil, nil, nil)
+
+	input := TaskDefCreateOrchestrationInput{
+		TaskDefinition: &ecs.RegisterTaskDefinitionInput{},
+		Cluster: &ecs.CreateClusterInput{
+			ClusterName: aws.String("cluster0"),
+		},
+	}
+	if _, _, err := orchestrator.processTaskCluster(context.TODO(), &input); err == nil {
 		t.Error("expected error, got nil")
 	}
 }

--- a/orchestration/iam_test.go
+++ b/orchestration/iam_test.go
@@ -362,7 +362,7 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 			o := &Orchestrator{
 				IAM: tt.fields.IAM,
 			}
-			got, err := o.DefaultTaskExecutionRole(tt.args.ctx, tt.args.path, tt.args.role)
+			got, err := o.DefaultTaskExecutionRole(tt.args.ctx, tt.args.path, tt.args.role, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Orchestrator.DefaultTaskExecutionRole() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/orchestration/orchestration_service.go
+++ b/orchestration/orchestration_service.go
@@ -213,7 +213,7 @@ func (o *Orchestrator) DeleteService(ctx context.Context, input *ServiceDeleteIn
 			}
 
 			// get the active task definition to find the task definition family
-			taskDefinition, err := o.ECS.GetTaskDefinition(cleanupCtx, service.TaskDefinition)
+			taskDefinition, _, err := o.ECS.GetTaskDefinition(cleanupCtx, service.TaskDefinition)
 			if err != nil {
 				log.Errorf("failed to get active task definition '%s': %s", aws.StringValue(service.TaskDefinition), err)
 			} else {
@@ -224,7 +224,7 @@ func (o *Orchestrator) DeleteService(ctx context.Context, input *ServiceDeleteIn
 				} else {
 					for _, revision := range taskDefinitionRevisions {
 
-						taskDefinition, err := o.ECS.GetTaskDefinition(cleanupCtx, aws.String(revision))
+						taskDefinition, _, err := o.ECS.GetTaskDefinition(cleanupCtx, aws.String(revision))
 						if err != nil {
 							log.Errorf("failed to get task definition revisions '%s' to delete: %s", revision, err)
 							continue
@@ -293,7 +293,7 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 	active.Service = svc
 
 	// get the active task def
-	tdef, err := o.ECS.GetTaskDefinition(ctx, active.Service.TaskDefinition)
+	tdef, _, err := o.ECS.GetTaskDefinition(ctx, active.Service.TaskDefinition)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestration/orchestration_service.go
+++ b/orchestration/orchestration_service.go
@@ -112,7 +112,7 @@ func (o *Orchestrator) CreateService(ctx context.Context, input *ServiceOrchestr
 	}()
 
 	output := &ServiceOrchestrationOutput{}
-	cluster, rbfunc, err := o.processCluster(ctx, input)
+	cluster, rbfunc, err := o.processServiceCluster(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestration/orchestration_service.go
+++ b/orchestration/orchestration_service.go
@@ -325,10 +325,11 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 
 	// if the input tags are passed, clean them and use them, otherwise set to the active service tags
 	if input.Tags != nil {
-		input.Tags, err = cleanTags(o.Org, input.Tags)
+		ct, err := cleanTags(o.Org, cluster, input.Tags)
 		if err != nil {
 			return nil, err
 		}
+		input.Tags = ct
 	} else {
 		inputTags := make([]*Tag, len(tags))
 		for i, t := range tags {

--- a/orchestration/orchestration_task.go
+++ b/orchestration/orchestration_task.go
@@ -10,7 +10,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
-s
+
+// TaskCreateOrchestrationInput is the input payload for creating a task
 type TaskCreateOrchestrationInput struct {
 	Cluster        *ecs.CreateClusterInput
 	TaskDefinition *ecs.RegisterTaskDefinitionInput
@@ -18,8 +19,12 @@ type TaskCreateOrchestrationInput struct {
 	Tags           []*Tag
 }
 
-type TaskCreateOrchestrationOutput struct{}
+// TaskCreateOrchestrationOutput is the output payload for a task creation
+type TaskCreateOrchestrationOutput struct {
+	Cluster *ecs.Cluster
+}
 
+// CreateTask orchestrates the creation of a task
 func (o *Orchestrator) CreateTask(ctx context.Context, input *TaskCreateOrchestrationInput) (*TaskCreateOrchestrationOutput, error) {
 	log.Debugf("got create task orchestration input object:\n %+v", input.TaskDefinition)
 	if input.TaskDefinition == nil {
@@ -42,7 +47,7 @@ func (o *Orchestrator) CreateTask(ctx context.Context, input *TaskCreateOrchestr
 	}()
 
 	output := &TaskCreateOrchestrationOutput{}
-	cluster, rbfunc, err := o.processCluster(ctx, input)
+	cluster, rbfunc, err := o.processTaskCluster(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestration/orchestration_taskdef.go
+++ b/orchestration/orchestration_taskdef.go
@@ -3,8 +3,12 @@ package orchestration
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/YaleSpinup/ecs-api/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -27,6 +31,25 @@ type TaskDefCreateOrchestrationOutput struct {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#CreateSecretOutput
 	Credentials    map[string]*secretsmanager.CreateSecretOutput
 	TaskDefinition *ecs.TaskDefinition
+}
+
+// TaskDefDeleteInput encapsulates a request to delete a taskdef with optional recursion
+type TaskDefDeleteInput struct {
+	Cluster        string
+	TaskDefinition string
+	Recursive      bool
+}
+
+// TaskDefDeleteOutput is the orchestration response for taskdef deletion
+type TaskDefDeleteOutput struct {
+	Cluster        string
+	TaskDefinition string
+}
+
+type TaskDefShowOutput struct {
+	Cluster        *ecs.Cluster
+	TaskDefinition *ecs.TaskDefinition
+	Tags           []*ecs.Tag
 }
 
 // CreateTask orchestrates the creation of a task.  It creates a cluster, creates repository credrentials in
@@ -78,4 +101,172 @@ func (o *Orchestrator) CreateTaskDef(ctx context.Context, input *TaskDefCreateOr
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
 	return output, nil
+}
+
+func (o *Orchestrator) DeleteTaskDef(ctx context.Context, input *TaskDefDeleteInput) (*TaskDefDeleteOutput, error) {
+	output := TaskDefDeleteOutput{
+		Cluster:        input.Cluster,
+		TaskDefinition: input.TaskDefinition,
+	}
+
+	taskDefinition, _, err := o.ECS.GetTaskDefinition(ctx, aws.String(input.TaskDefinition))
+	if err != nil {
+		return nil, err
+	}
+
+	// list all of the revisions in the task definition family
+	taskDefinitionRevisions, err := o.ECS.ListTaskDefinitionRevisions(ctx, taskDefinition.Family)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(taskDefinitionRevisions) == 0 {
+		return nil, fmt.Errorf("expected more than 0 task definition revisions for %s", aws.StringValue(taskDefinition.Family))
+	}
+
+	// for each task definition revision in the task definition family, delete any existing repository credentials, keeping track
+	// of ones we delete so we don't try to re-delete them.
+	// TODO: if we want to share repository credentials, we need to look for multiple container definitions using the same credentials.
+	deletedCredentials := make(map[string]struct{})
+
+	// delete the first task definition
+	if err := o.deleteTaskDefinitionRevision(ctx, taskDefinitionRevisions[0], deletedCredentials); err != nil {
+		return nil, fmt.Errorf("failed to delete task definition revision %s: %+v", taskDefinitionRevisions[0], err)
+	}
+
+	// delete the remaining revisions in the background
+	if len(taskDefinitionRevisions) > 1 {
+		go func(revList []string) {
+			cleanupCtx := context.Background()
+			for _, revision := range taskDefinitionRevisions {
+				if err := o.deleteTaskDefinitionRevision(cleanupCtx, revision, deletedCredentials); err != nil {
+					log.Errorf("failed to delete task def revision %s: %+v", revision, err)
+					continue
+				}
+			}
+		}(taskDefinitionRevisions[1:])
+	}
+
+	// TODO cleanup cluster
+
+	return &output, nil
+}
+
+// deleteTaskDefinitionRevision deletes a task definition revision and associated secretsmanager secrets.  It keeps track
+// of deleted secrets through the deleteCredentials map
+func (o *Orchestrator) deleteTaskDefinitionRevision(ctx context.Context, revision string, deletedCredentials map[string]struct{}) []error {
+	var errors []error
+	taskDefinition, _, err := o.ECS.GetTaskDefinition(ctx, aws.String(revision))
+	if err != nil {
+		log.Errorf("failed to get task definition revisions '%s' to delete: %s", revision, err)
+		return []error{err}
+	}
+
+	for _, cd := range taskDefinition.ContainerDefinitions {
+		tdArn := aws.StringValue(taskDefinition.TaskDefinitionArn)
+		log.Debugf("cleaning '%s' container definition '%s' components", tdArn, aws.StringValue(cd.Name))
+
+		if cd.RepositoryCredentials != nil && aws.StringValue(cd.RepositoryCredentials.CredentialsParameter) != "" {
+			credsArn := aws.StringValue(cd.RepositoryCredentials.CredentialsParameter)
+
+			if _, ok := deletedCredentials[credsArn]; !ok {
+				_, err = o.SecretsManager.DeleteSecret(ctx, credsArn, 0)
+				if err != nil {
+					errors = append(errors, err)
+					continue
+				}
+
+				deletedCredentials[credsArn] = struct{}{}
+				log.Infof("successfully deleted secretsmanager secret '%s'", credsArn)
+			}
+		}
+	}
+
+	out, err := o.ECS.DeleteTaskDefinition(ctx, aws.String(revision))
+	if err != nil {
+		log.Errorf("failed to delete task definition '%s': %s", revision, err)
+		return append(errors, err)
+	}
+
+	log.Debugf("successfully deleted task definition revision %s: %+v", revision, out)
+
+	return errors
+}
+
+func (o *Orchestrator) ListTaskDefs(ctx context.Context, cluster string) ([]string, error) {
+	log.Infof("listing task definitions in cluster '%s'", cluster)
+
+	tagFilters := []*resourcegroupstaggingapi.TagFilter{
+		{
+			Key:   "spinup:org",
+			Value: []string{o.Org},
+		},
+		{
+			Key:   "spinup:category",
+			Value: []string{"container-taskdef"},
+		},
+	}
+
+	if cluster != "" {
+		tagFilters = append(tagFilters, &resourcegroupstaggingapi.TagFilter{
+			Key:   "spinup:spaceid",
+			Value: []string{cluster},
+		})
+	}
+
+	taskDefinitionRevisions, err := o.ResourceGroupsTaggingAPI.GetResourcesWithTags(ctx, []string{"ecs:task-definition"}, tagFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	// get a unique list of task definition families from the list of revisions
+	families := map[string]struct{}{}
+	for _, td := range taskDefinitionRevisions {
+		tdArn, err := arn.Parse(td)
+		if err != nil {
+			log.Warnf("failed to parse ARN %s: %s", tdArn, err)
+			families[td] = struct{}{}
+			continue
+		}
+
+		parts := strings.SplitN(tdArn.Resource, ":", 2)
+		family := strings.TrimPrefix(parts[0], "task-definition/")
+
+		log.Debugf("got family %s from arn %s", family, tdArn)
+
+		families[family] = struct{}{}
+	}
+
+	taskDefinitionFamilies := make([]string, len(families))
+	i := 0
+	for f := range families {
+		taskDefinitionFamilies[i] = f
+		i++
+	}
+
+	return taskDefinitionFamilies, nil
+}
+
+func (o *Orchestrator) GetTaskDef(ctx context.Context, cluster, family string) (*TaskDefShowOutput, error) {
+	if cluster == "" || family == "" {
+		return nil, errors.New("cluster and task def family are required")
+	}
+
+	log.Debugf("getting task definition for %s/%s", cluster, family)
+
+	cluOutput, err := o.ECS.GetCluster(ctx, aws.String(cluster))
+	if err != nil {
+		return nil, err
+	}
+
+	tdOutput, tags, err := o.ECS.GetTaskDefinition(ctx, aws.String(family))
+	if err != nil {
+		return nil, err
+	}
+
+	return &TaskDefShowOutput{
+		Cluster:        cluOutput,
+		TaskDefinition: tdOutput,
+		Tags:           tags,
+	}, nil
 }

--- a/orchestration/orchestration_test.go
+++ b/orchestration/orchestration_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/aws-sdk-go/service/servicediscovery/servicediscoveryiface"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
 
@@ -43,32 +41,6 @@ type mockSMClient struct {
 	t   *testing.T
 	err error
 }
-
-var (
-	credentialsMapIn = map[string]*secretsmanager.CreateSecretInput{
-		"testDef1": {
-			Name:         aws.String("testDef1"),
-			SecretString: aws.String("shhhhhhh"),
-		},
-		"testDef2": {
-			Name:         aws.String("testDef2"),
-			SecretString: aws.String("donttell"),
-		},
-	}
-
-	credentialsMapOut = map[string]*secretsmanager.CreateSecretOutput{
-		"testDef1": {
-			ARN:       aws.String("arn:spinup/mock/getAClu1/testDef1"),
-			Name:      aws.String("spinup/mock/getAClu1/testDef1"),
-			VersionId: aws.String("v1"),
-		},
-		"testDef2": {
-			ARN:       aws.String("arn:spinup/mock/getAClu1/testDef2"),
-			Name:      aws.String("spinup/mock/getAClu1/testDef2"),
-			VersionId: aws.String("v1"),
-		},
-	}
-)
 
 func newMockCWLClient(t *testing.T, err error) cloudwatchlogsiface.CloudWatchLogsAPI {
 	return &mockCWLClient{

--- a/orchestration/orchestration_test.go
+++ b/orchestration/orchestration_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
@@ -30,6 +32,12 @@ type mockIAMClient struct {
 	err error
 }
 
+type mockRGTAClient struct {
+	resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+	t   *testing.T
+	err error
+}
+
 type mockSDClient struct {
 	servicediscoveryiface.ServiceDiscoveryAPI
 	t   *testing.T
@@ -43,36 +51,67 @@ type mockSMClient struct {
 }
 
 func newMockCWLClient(t *testing.T, err error) cloudwatchlogsiface.CloudWatchLogsAPI {
-	return &mockCWLClient{
+	m := mockCWLClient{
 		t:   t,
 		err: err,
 	}
+
+	log.Infof("returning mock cloudwatchlogs client %+v", m)
+
+	return &m
 }
 
 func newMockECSClient(t *testing.T, err error) ecsiface.ECSAPI {
-	return &mockECSClient{
+	m := mockECSClient{
 		t:   t,
 		err: err,
 	}
+
+	log.Infof("returning mock ecs client %+v", m)
+
+	return &m
 }
 
 func newMockIAMClient(t *testing.T, err error) iamiface.IAMAPI {
-	return &mockIAMClient{
+	m := mockIAMClient{
 		t:   t,
 		err: err,
 	}
+
+	log.Infof("returning mock iam client %+v", m)
+
+	return &m
+}
+
+func newMockResourceGroupTaggingApiClient(t *testing.T, err error) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
+	m := mockRGTAClient{
+		t:   t,
+		err: err,
+	}
+
+	log.Infof("returning mock resourcegrouptaggingapi client %+v", m)
+
+	return &m
 }
 
 func newMockSMClient(t *testing.T, err error) secretsmanageriface.SecretsManagerAPI {
-	return &mockSMClient{
+	m := mockSMClient{
 		t:   t,
 		err: err,
 	}
+
+	log.Infof("returning mock secretsmanager client %+v", m)
+
+	return &m
 }
 
 func newMockSDClient(t *testing.T, err error) servicediscoveryiface.ServiceDiscoveryAPI {
-	return &mockSDClient{
+	m := mockSDClient{
 		t:   t,
 		err: err,
 	}
+
+	log.Infof("returning mock servicediscovery client %+v", m)
+
+	return &m
 }

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YaleSpinup/ecs-api/cloudwatchlogs"
 	"github.com/YaleSpinup/ecs-api/ecs"
 	"github.com/YaleSpinup/ecs-api/iam"
+	"github.com/YaleSpinup/ecs-api/resourcegroupstaggingapi"
 	"github.com/YaleSpinup/ecs-api/secretsmanager"
 	"github.com/YaleSpinup/ecs-api/servicediscovery"
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,6 +46,8 @@ type Orchestrator struct {
 	ECS ecs.ECS
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#IAM
 	IAM iam.IAM
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/resourcegroupstaggingapi/
+	ResourceGroupsTaggingAPI resourcegroupstaggingapi.ResourceGroupsTaggingAPI
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#SecretsManager
 	SecretsManager secretsmanager.SecretsManager
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/servicediscovery/#ServiceDiscovery

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -17,6 +17,11 @@ import (
 )
 
 var (
+	// DefaultCapacityProviders are the default capacity providers for a cluster
+	DefaultCapacityProviders = []*string{
+		aws.String("FARGATE"),
+		aws.String("FARGATE_SPOT"),
+	}
 	// DefaultCompatabilities sets the default task definition compatabilities to
 	// Fargate.  By default, we won't support standard ECS.
 	// https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -89,3 +89,10 @@ func rollBack(t *[]rollbackFunc) {
 		log.Info("successfully rolled back")
 	}
 }
+
+func defaultRbfunc(name string) rollbackFunc {
+	return func(_ context.Context) error {
+		log.Infof("%s rollback, nothing to do", name)
+		return nil
+	}
+}

--- a/orchestration/orchestrator_test.go
+++ b/orchestration/orchestrator_test.go
@@ -6,19 +6,26 @@ import (
 	"github.com/YaleSpinup/ecs-api/cloudwatchlogs"
 	"github.com/YaleSpinup/ecs-api/ecs"
 	"github.com/YaleSpinup/ecs-api/iam"
+	"github.com/YaleSpinup/ecs-api/resourcegroupstaggingapi"
 	"github.com/YaleSpinup/ecs-api/secretsmanager"
 	"github.com/YaleSpinup/ecs-api/servicediscovery"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
-func newMockOrchestrator(t *testing.T, org string, cwlerr, ecserr, iamerr, smerr, sderr error) *Orchestrator {
-	return &Orchestrator{
-		CloudWatchLogs:   cloudwatchlogs.CloudWatchLogs{Service: newMockCWLClient(t, cwlerr)},
-		ECS:              ecs.ECS{Service: newMockECSClient(t, ecserr)},
-		IAM:              iam.IAM{Service: newMockIAMClient(t, iamerr)},
-		SecretsManager:   secretsmanager.SecretsManager{Service: newMockSMClient(t, smerr)},
-		ServiceDiscovery: servicediscovery.ServiceDiscovery{Service: newMockSDClient(t, sderr)},
-		Token:            uuid.New().String(),
-		Org:              org,
+func newMockOrchestrator(t *testing.T, org string, cwlerr, ecserr, iamerr, rgtaerr, smerr, sderr error) *Orchestrator {
+	o := Orchestrator{
+		CloudWatchLogs:           cloudwatchlogs.CloudWatchLogs{Service: newMockCWLClient(t, cwlerr)},
+		ECS:                      ecs.ECS{Service: newMockECSClient(t, ecserr)},
+		IAM:                      iam.IAM{Service: newMockIAMClient(t, iamerr)},
+		ResourceGroupsTaggingAPI: resourcegroupstaggingapi.ResourceGroupsTaggingAPI{Service: newMockResourceGroupTaggingApiClient(t, rgtaerr)},
+		SecretsManager:           secretsmanager.SecretsManager{Service: newMockSMClient(t, smerr)},
+		ServiceDiscovery:         servicediscovery.ServiceDiscovery{Service: newMockSDClient(t, sderr)},
+		Token:                    uuid.New().String(),
+		Org:                      org,
 	}
+
+	log.Infof("Returning new mock orchestrator: %+v", o)
+
+	return &o
 }

--- a/orchestration/service.go
+++ b/orchestration/service.go
@@ -12,10 +12,7 @@ import (
 
 // processService processes the service input.  It normalizes inputs and creates the ECS service.
 func (o *Orchestrator) processService(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.Service, rollbackFunc, error) {
-	rbfunc := func(_ context.Context) error {
-		log.Infof("processService rollback, nothing to do")
-		return nil
-	}
+	rbfunc := defaultRbfunc("processService")
 
 	if input.Service.ClientToken == nil {
 		input.Service.ClientToken = aws.String(o.Token)

--- a/orchestration/tags.go
+++ b/orchestration/tags.go
@@ -1,0 +1,57 @@
+package orchestration
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+// ecsTags takes a slice of tags and converts them to ECS tags
+func ecsTags(input []*Tag) []*ecs.Tag {
+	et := make([]*ecs.Tag, len(input))
+	for i, t := range input {
+		et[i] = &ecs.Tag{Key: t.Key, Value: t.Value}
+	}
+	return et
+}
+
+func secretsmanagerTags(tags []*Tag) []*secretsmanager.Tag {
+	st := make([]*secretsmanager.Tag, len(tags))
+	for i, t := range tags {
+		st[i] = &secretsmanager.Tag{Key: t.Key, Value: t.Value}
+	}
+	return st
+}
+
+// cleanTags cleanses the tags input and ensures spinup:org and spinup:spaceid are set correctly
+func cleanTags(org, spaceid string, tags []*Tag) ([]*Tag, error) {
+	cleanTags := []*Tag{
+		{
+			Key:   aws.String("spinup:org"),
+			Value: aws.String(org),
+		},
+		{
+			Key:   aws.String("spinup:spaceid"),
+			Value: aws.String(spaceid),
+		},
+	}
+
+	for _, t := range tags {
+		if aws.StringValue(t.Key) != "spinup:org" && aws.StringValue(t.Key) != "yale:org" && aws.StringValue(t.Key) != "spinup:spaceid" {
+			cleanTags = append(cleanTags, &Tag{Key: t.Key, Value: t.Value})
+			continue
+		}
+
+		if aws.StringValue(t.Key) == "spinup:org" || aws.StringValue(t.Key) == "yale:org" {
+			if aws.StringValue(t.Value) != org {
+				msg := fmt.Sprintf("not a part of our org (%s)", org)
+				return nil, errors.New(msg)
+			}
+		}
+	}
+
+	return cleanTags, nil
+}

--- a/orchestration/tags_test.go
+++ b/orchestration/tags_test.go
@@ -1,0 +1,84 @@
+package orchestration
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+func TestSecretsmanagerTags(t *testing.T) {
+	var tests = []struct {
+		input  []*Tag
+		output []*secretsmanager.Tag
+	}{
+		{
+			input: []*Tag{
+				{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+			},
+			output: []*secretsmanager.Tag{
+				{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+			},
+		},
+		{
+			input: []*Tag{
+				{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+				{
+					Key:   aws.String("spinup:org"),
+					Value: aws.String("someOtherOrg"),
+				},
+			},
+			output: []*secretsmanager.Tag{
+				{
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				},
+				{
+					Key:   aws.String("spinup:org"),
+					Value: aws.String("someOtherOrg"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		out := secretsmanagerTags(test.input)
+
+		if !reflect.DeepEqual(test.output, out) {
+			t.Errorf("expected %+v, got %+v", test.output, out)
+		}
+
+		for _, tag := range test.output {
+			exists := false
+			t.Logf("testing for test tag key: %v, value: %v", tag.Key, tag.Value)
+
+			for _, otag := range out {
+				t.Logf("testing output tag key: %v, value: %v", otag.Key, otag.Value)
+				if aws.StringValue(otag.Key) == aws.StringValue(tag.Key) {
+					value := aws.StringValue(tag.Value)
+					ovalue := aws.StringValue(otag.Value)
+					if value != ovalue {
+						t.Errorf("expected tag %s value to be %s, got %s", aws.StringValue(tag.Key), value, ovalue)
+					}
+					exists = true
+					break
+				}
+			}
+
+			if !exists {
+				t.Errorf("expected tag %+v to exist", tag)
+			}
+		}
+	}
+
+}

--- a/orchestration/task_orchestration.go
+++ b/orchestration/task_orchestration.go
@@ -1,0 +1,53 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+
+	log "github.com/sirupsen/logrus"
+)
+s
+type TaskCreateOrchestrationInput struct {
+	Cluster        *ecs.CreateClusterInput
+	TaskDefinition *ecs.RegisterTaskDefinitionInput
+	Credentials    map[string]*secretsmanager.CreateSecretInput
+	Tags           []*Tag
+}
+
+type TaskCreateOrchestrationOutput struct{}
+
+func (o *Orchestrator) CreateTask(ctx context.Context, input *TaskCreateOrchestrationInput) (*TaskCreateOrchestrationOutput, error) {
+	log.Debugf("got create task orchestration input object:\n %+v", input.TaskDefinition)
+	if input.TaskDefinition == nil {
+		return nil, errors.New("task definition is required")
+	}
+
+	ct, err := cleanTags(o.Org, input.Tags)
+	if err != nil {
+		return nil, err
+	}
+	input.Tags = ct
+
+	// setup err var, rollback function list and defer execution, note that we depend on the err variable defined above this
+	var rollBackTasks []rollbackFunc
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			go rollBack(&rollBackTasks)
+		}
+	}()
+
+	output := &TaskCreateOrchestrationOutput{}
+	cluster, rbfunc, err := o.processCluster(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	output.Cluster = cluster
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	return nil, nil
+}

--- a/orchestration/taskdefinition.go
+++ b/orchestration/taskdefinition.go
@@ -5,105 +5,129 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/YaleSpinup/apierror"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/iam"
 	log "github.com/sirupsen/logrus"
 )
 
-// processTaskDefinition processes the task definition portion of the input.  If the task definition is provided with
-// the service object, it is used.  Otherwise, if the task definition is defined as input, it will be created.  If neither
-// is true, an error is returned.
-func (o *Orchestrator) processTaskDefinition(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.TaskDefinition, rollbackFunc, error) {
-	rbfunc := func(_ context.Context) error {
-		log.Infof("processTaskDefinition rollback, nothing to do")
+// processTaskDefinitionCreate processes the task definition portion of the input.  If the task definition is defined as input,
+// it will be created otherwiuse an error is returned.
+func (o *Orchestrator) processTaskDefinitionCreate(ctx context.Context, input *ServiceOrchestrationInput) (*ecs.TaskDefinition, rollbackFunc, error) {
+	rbfunc := defaultRbfunc("processTaskDefinitionCreate")
+
+	log.Debugf("creating task definition for a service %+v", input.TaskDefinition)
+
+	if input.TaskDefinition == nil {
+		return nil, rbfunc, apierror.New(apierror.ErrBadRequest, "task definition cannot be empty", nil)
+	}
+
+	input.TaskDefinition.Tags = ecsTags(input.Tags)
+
+	// path is org/clustername
+	path := fmt.Sprintf("%s/%s", o.Org, aws.StringValue(input.Cluster.ClusterName))
+
+	// role name is clustername-ecsTaskExecution
+	roleName := fmt.Sprintf("%s-ecsTaskExecution", aws.StringValue(input.Cluster.ClusterName))
+
+	roleARN, err := o.DefaultTaskExecutionRole(ctx, path, roleName, input.Tags)
+	if err != nil {
+		return nil, rbfunc, err
+	}
+
+	input.TaskDefinition.ExecutionRoleArn = &roleARN
+	input.TaskDefinition.RequiresCompatibilities = DefaultCompatabilities
+	input.TaskDefinition.NetworkMode = DefaultNetworkMode
+
+	logConfiguration, err := o.defaultLogConfiguration(ctx, aws.StringValue(input.Cluster.ClusterName), aws.StringValue(input.TaskDefinition.Family), input.Tags)
+	if err != nil {
+		return nil, rbfunc, err
+	}
+
+	for _, cd := range input.TaskDefinition.ContainerDefinitions {
+		cd.SetLogConfiguration(logConfiguration)
+	}
+
+	taskDefinition, err := o.ECS.CreateTaskDefinition(ctx, input.TaskDefinition)
+	if err != nil {
+		return nil, rbfunc, err
+	}
+
+	rbfunc = func(ctx context.Context) error {
+		id := aws.StringValue(taskDefinition.TaskDefinitionArn)
+		log.Debugf("rolling back task definition %s", id)
+
+		_, err := o.ECS.DeleteTaskDefinition(ctx, taskDefinition.TaskDefinitionArn)
+		if err != nil {
+			return fmt.Errorf("failed to delete task definition %s: %s", id, err)
+		}
+
+		log.Infof("successfully rolled back task definition %s", id)
 		return nil
 	}
 
-	if input.Service.TaskDefinition != nil {
-		log.Infof("using provided task definition %s", aws.StringValue(input.Service.TaskDefinition))
-		taskDefinition, err := o.ECS.GetTaskDefinition(ctx, input.Service.TaskDefinition)
-		if err != nil {
-			return nil, rbfunc, err
-		}
-		return taskDefinition, rbfunc, nil
-	} else if input.TaskDefinition != nil {
-		ecsTags := make([]*ecs.Tag, len(input.Tags))
-		for i, t := range input.Tags {
-			ecsTags[i] = &ecs.Tag{Key: t.Key, Value: t.Value}
-		}
-		input.TaskDefinition.Tags = ecsTags
+	td := fmt.Sprintf("%s:%d", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
+	input.Service.TaskDefinition = aws.String(td)
+	return taskDefinition, rbfunc, nil
+}
 
-		log.Infof("creating task definition %+v", input.TaskDefinition)
+func (o *Orchestrator) processTaskTaskDefinitionCreate(ctx context.Context, input *TaskDefCreateOrchestrationInput) (*ecs.TaskDefinition, rollbackFunc, error) {
+	log.Debugf("creating task definition for a task %+v", input.TaskDefinition)
 
-		if input.TaskDefinition.ExecutionRoleArn == nil {
-			// path is org/clustername
-			path := fmt.Sprintf("%s/%s", o.Org, aws.StringValue(input.Cluster.ClusterName))
+	rbfunc := defaultRbfunc("processTaskTaskDefinitionCreate")
 
-			// role name is clustername-ecsTaskExecution
-			roleName := fmt.Sprintf("%s-ecsTaskExecution", aws.StringValue(input.Cluster.ClusterName))
-
-			roleARN, err := o.DefaultTaskExecutionRole(ctx, path, roleName)
-			if err != nil {
-				return nil, rbfunc, err
-			}
-
-			iamTags := make([]*iam.Tag, len(input.Tags))
-			for i, t := range input.Tags {
-				iamTags[i] = &iam.Tag{Key: t.Key, Value: t.Value}
-			}
-
-			if err := o.IAM.TagRole(ctx, roleName, iamTags); err != nil {
-				return nil, rbfunc, err
-			}
-
-			input.TaskDefinition.ExecutionRoleArn = &roleARN
-		}
-
-		if len(input.TaskDefinition.RequiresCompatibilities) == 0 {
-			input.TaskDefinition.RequiresCompatibilities = DefaultCompatabilities
-		}
-
-		if input.TaskDefinition.NetworkMode == nil {
-			input.TaskDefinition.NetworkMode = DefaultNetworkMode
-		}
-
-		logConfiguration, err := o.processLogConfiguration(ctx, aws.StringValue(input.Cluster.ClusterName), aws.StringValue(input.TaskDefinition.Family), input.Tags)
-		if err != nil {
-			return nil, rbfunc, err
-		}
-
-		for _, cd := range input.TaskDefinition.ContainerDefinitions {
-			cd.SetLogConfiguration(logConfiguration)
-		}
-
-		taskDefinition, err := o.ECS.CreateTaskDefinition(ctx, input.TaskDefinition)
-		if err != nil {
-			return nil, rbfunc, err
-		}
-
-		rbfunc = func(ctx context.Context) error {
-			id := aws.StringValue(taskDefinition.TaskDefinitionArn)
-			log.Debugf("rolling back task definition %s", id)
-
-			_, err := o.ECS.DeleteTaskDefinition(ctx, taskDefinition.TaskDefinitionArn)
-			if err != nil {
-				return fmt.Errorf("failed to delete task definition %s: %s", id, err)
-			}
-
-			log.Infof("successfully rolled back task definition %s", id)
-			return nil
-		}
-
-		td := fmt.Sprintf("%s:%d", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
-		input.Service.TaskDefinition = aws.String(td)
-		return taskDefinition, rbfunc, nil
+	if input.TaskDefinition == nil {
+		return nil, rbfunc, apierror.New(apierror.ErrBadRequest, "task definition cannot be empty", nil)
 	}
 
-	return nil, rbfunc, errors.New("taskDefinition or service task definition name is required")
+	input.TaskDefinition.Tags = ecsTags(input.Tags)
+
+	// path is org/clustername
+	path := fmt.Sprintf("%s/%s", o.Org, aws.StringValue(input.Cluster.ClusterName))
+
+	// role name is clustername-ecsTaskExecution
+	roleName := fmt.Sprintf("%s-ecsTaskExecution", aws.StringValue(input.Cluster.ClusterName))
+
+	roleARN, err := o.DefaultTaskExecutionRole(ctx, path, roleName, input.Tags)
+	if err != nil {
+		return nil, rbfunc, err
+	}
+
+	input.TaskDefinition.ExecutionRoleArn = &roleARN
+	input.TaskDefinition.RequiresCompatibilities = DefaultCompatabilities
+	input.TaskDefinition.NetworkMode = DefaultNetworkMode
+
+	logConfiguration, err := o.defaultLogConfiguration(ctx, aws.StringValue(input.Cluster.ClusterName), aws.StringValue(input.TaskDefinition.Family), input.Tags)
+	if err != nil {
+		return nil, rbfunc, err
+	}
+
+	for _, cd := range input.TaskDefinition.ContainerDefinitions {
+		cd.SetLogConfiguration(logConfiguration)
+	}
+
+	taskDefinition, err := o.ECS.CreateTaskDefinition(ctx, input.TaskDefinition)
+	if err != nil {
+		return nil, rbfunc, err
+	}
+
+	rbfunc = func(ctx context.Context) error {
+		id := aws.StringValue(taskDefinition.TaskDefinitionArn)
+		log.Debugf("rolling back task definition %s", id)
+
+		_, err := o.ECS.DeleteTaskDefinition(ctx, taskDefinition.TaskDefinitionArn)
+		if err != nil {
+			return fmt.Errorf("failed to delete task definition %s: %s", id, err)
+		}
+
+		log.Infof("successfully rolled back task definition %s", id)
+		return nil
+	}
+
+	return taskDefinition, rbfunc, nil
 }
 
 // processTaskDefinitionUpdate processes the task definition portion of the input
@@ -119,7 +143,7 @@ func (o *Orchestrator) processTaskDefinitionUpdate(ctx context.Context, input *S
 		// role name is clustername-ecsTaskExecution
 		roleName := fmt.Sprintf("%s-ecsTaskExecution", input.ClusterName)
 
-		roleARN, err := o.DefaultTaskExecutionRole(ctx, path, roleName)
+		roleARN, err := o.DefaultTaskExecutionRole(ctx, path, roleName, input.Tags)
 		if err != nil {
 			return err
 		}
@@ -138,7 +162,7 @@ func (o *Orchestrator) processTaskDefinitionUpdate(ctx context.Context, input *S
 		input.TaskDefinition.NetworkMode = DefaultNetworkMode
 	}
 
-	logConfiguration, err := o.processLogConfiguration(ctx, input.ClusterName, aws.StringValue(input.TaskDefinition.Family), input.Tags)
+	logConfiguration, err := o.defaultLogConfiguration(ctx, input.ClusterName, aws.StringValue(input.TaskDefinition.Family), input.Tags)
 	if err != nil {
 		return err
 	}
@@ -165,7 +189,8 @@ func (o *Orchestrator) processTaskDefinitionUpdate(ctx context.Context, input *S
 	return nil
 }
 
-func (o *Orchestrator) processLogConfiguration(ctx context.Context, logGroup, streamPrefix string, tags []*Tag) (*ecs.LogConfiguration, error) {
+// defaultLogConfiguration generates a log group and sets retention on the log group.  It returns the default log configuration.
+func (o *Orchestrator) defaultLogConfiguration(ctx context.Context, logGroup, streamPrefix string, tags []*Tag) (*ecs.LogConfiguration, error) {
 	if logGroup == "" {
 		return nil, errors.New("cloudwatch logs group name cannot be empty")
 	}
@@ -175,11 +200,10 @@ func (o *Orchestrator) processLogConfiguration(ctx context.Context, logGroup, st
 		tagsMap[aws.StringValue(tag.Key)] = tag.Value
 	}
 
-	err := o.CloudWatchLogs.CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
+	if err := o.CloudWatchLogs.CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
 		LogGroupName: aws.String(logGroup),
 		Tags:         tagsMap,
-	})
-	if err != nil {
+	}); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case cloudwatchlogs.ErrCodeResourceAlreadyExistsException:

--- a/orchestration/taskdefinition_test.go
+++ b/orchestration/taskdefinition_test.go
@@ -1,0 +1,638 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+func (m *mockCWLClient) CreateLogGroupWithContext(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput, opts ...request.Option) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &cloudwatchlogs.CreateLogGroupOutput{}, nil
+}
+
+func (m *mockCWLClient) PutRetentionPolicyWithContext(ctx context.Context, input *cloudwatchlogs.PutRetentionPolicyInput, opts ...request.Option) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
+	return &cloudwatchlogs.PutRetentionPolicyOutput{}, nil
+}
+
+func (m *mockECSClient) RegisterTaskDefinitionWithContext(ctx aws.Context, input *ecs.RegisterTaskDefinitionInput, opts ...request.Option) (*ecs.RegisterTaskDefinitionOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	output := &ecs.RegisterTaskDefinitionOutput{
+		Tags: input.Tags,
+		TaskDefinition: &ecs.TaskDefinition{
+			Compatibilities:         input.RequiresCompatibilities,
+			ContainerDefinitions:    input.ContainerDefinitions,
+			Cpu:                     input.Cpu,
+			ExecutionRoleArn:        input.ExecutionRoleArn,
+			Family:                  input.Family,
+			InferenceAccelerators:   input.InferenceAccelerators,
+			IpcMode:                 input.IpcMode,
+			Memory:                  input.Memory,
+			NetworkMode:             input.NetworkMode,
+			PidMode:                 input.PidMode,
+			PlacementConstraints:    input.PlacementConstraints,
+			ProxyConfiguration:      input.ProxyConfiguration,
+			RequiresAttributes:      []*ecs.Attribute{},
+			RequiresCompatibilities: input.RequiresCompatibilities,
+			Revision:                aws.Int64(1),
+			Status:                  aws.String("ACTIVE"),
+			TaskDefinitionArn:       aws.String("arn:aws:ecs:us-east-1:0123456789:task-definition/" + aws.StringValue(input.Family) + ":1"),
+			TaskRoleArn:             input.TaskRoleArn,
+			Volumes:                 input.Volumes,
+		},
+	}
+
+	return output, nil
+}
+
+func (m *mockIAMClient) TagRoleWithContext(ctx context.Context, input *iam.TagRoleInput, opts ...request.Option) (*iam.TagRoleOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.TagRoleOutput{}, nil
+}
+
+func TestOrchestrator_processTaskDefinitionCreate(t *testing.T) {
+	t.Log("testing processTaskDefinitionCreate")
+
+	type fields struct {
+		org     string
+		cwlerr  error
+		ecserr  error
+		iamerr  error
+		rgtaerr error
+		smerr   error
+		sderr   error
+	}
+	type args struct {
+		ctx   context.Context
+		input *ServiceOrchestrationInput
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *ecs.TaskDefinition
+		// TODO test rollback function
+		// want1   rollbackFunc
+		wantErr bool
+	}{
+		{
+			name: "nil input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx:   context.TODO(),
+				input: &ServiceOrchestrationInput{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "example input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+				input: &ServiceOrchestrationInput{
+					Cluster: &ecs.CreateClusterInput{
+						ClusterName: aws.String("clu1"),
+					},
+					Service: &ecs.CreateServiceInput{},
+					TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+						ContainerDefinitions: []*ecs.ContainerDefinition{
+							{
+								Name:  aws.String("haxserver"),
+								Image: aws.String("nginx:alpine"),
+								PortMappings: []*ecs.PortMapping{
+									{ContainerPort: aws.Int64(80)},
+									{ContainerPort: aws.Int64(443)},
+								},
+							},
+						},
+						Cpu:    aws.String("256"),
+						Family: aws.String("datfam"),
+						Memory: aws.String("512"),
+					},
+					Tags: []*Tag{
+						{
+							Key:   aws.String("Application"),
+							Value: aws.String("derpderpderp"),
+						},
+					},
+				},
+			},
+			want: &ecs.TaskDefinition{
+				Compatibilities: aws.StringSlice([]string{"FARGATE"}),
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Image: aws.String("nginx:alpine"),
+						LogConfiguration: &ecs.LogConfiguration{
+							LogDriver: aws.String("awslogs"),
+							Options: map[string]*string{
+								"awslogs-group":         aws.String("clu1"),
+								"awslogs-stream-prefix": aws.String("datfam"),
+								"awslogs-region":        aws.String("us-east-1"),
+								"awslogs-create-group":  aws.String("true"),
+							},
+						},
+						Name: aws.String("haxserver"),
+						PortMappings: []*ecs.PortMapping{
+							{ContainerPort: aws.Int64(80)},
+							{ContainerPort: aws.Int64(443)},
+						},
+					},
+				},
+				Cpu:                     aws.String("256"),
+				Family:                  aws.String("datfam"),
+				Memory:                  aws.String("512"),
+				ExecutionRoleArn:        aws.String("arn:aws:iam::12345678910:role/clu1-ecsTaskExecution"),
+				NetworkMode:             aws.String("awsvpc"),
+				RequiresAttributes:      []*ecs.Attribute{},
+				RequiresCompatibilities: aws.StringSlice([]string{"FARGATE"}),
+				Revision:                aws.Int64(1),
+				Status:                  aws.String("ACTIVE"),
+				TaskDefinitionArn:       aws.String("arn:aws:ecs:us-east-1:0123456789:task-definition/datfam:1"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newMockOrchestrator(t, tt.fields.org,
+				tt.fields.cwlerr, tt.fields.ecserr, tt.fields.iamerr,
+				tt.fields.rgtaerr, tt.fields.smerr, tt.fields.sderr)
+			got, _, err := o.processTaskDefinitionCreate(tt.args.ctx, tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Orchestrator.processTaskDefinitionCreate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Orchestrator.processTaskDefinitionCreate() got = %v, want %v", got, tt.want)
+			}
+
+			if !tt.wantErr {
+				td := fmt.Sprintf("%s:%d", aws.StringValue(got.Family), aws.Int64Value(got.Revision))
+				if gottd := aws.StringValue(tt.args.input.Service.TaskDefinition); gottd != td {
+					t.Errorf("Orchestrator.processTaskDefinitionCreate() gottd = %v, want %v", gottd, td)
+				}
+			}
+
+			// if !reflect.DeepEqual(got1, tt.want1) {
+			// 	t.Errorf("Orchestrator.processTaskDefinitionCreate() got1 = %v, want %v", got1, tt.want1)
+			// }
+		})
+	}
+}
+
+func TestOrchestrator_processTaskTaskDefinitionCreate(t *testing.T) {
+	t.Log("testing processTaskTaskDefinitionCreate")
+
+	type fields struct {
+		org     string
+		cwlerr  error
+		ecserr  error
+		iamerr  error
+		rgtaerr error
+		smerr   error
+		sderr   error
+	}
+	type args struct {
+		ctx   context.Context
+		input *TaskDefCreateOrchestrationInput
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *ecs.TaskDefinition
+		// TODO test rollback function
+		// want1   rollbackFunc
+		wantErr bool
+	}{
+		{
+			name: "nil input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx:   context.TODO(),
+				input: &TaskDefCreateOrchestrationInput{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "example input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+				input: &TaskDefCreateOrchestrationInput{
+					Cluster: &ecs.CreateClusterInput{
+						ClusterName: aws.String("clu1"),
+					},
+					TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+						ContainerDefinitions: []*ecs.ContainerDefinition{
+							{
+								Name:  aws.String("haxserver"),
+								Image: aws.String("nginx:alpine"),
+								PortMappings: []*ecs.PortMapping{
+									{ContainerPort: aws.Int64(80)},
+									{ContainerPort: aws.Int64(443)},
+								},
+							},
+						},
+						Cpu:    aws.String("256"),
+						Family: aws.String("datfam"),
+						Memory: aws.String("512"),
+					},
+					Tags: []*Tag{
+						{
+							Key:   aws.String("Application"),
+							Value: aws.String("derpderpderp"),
+						},
+					},
+				},
+			},
+			want: &ecs.TaskDefinition{
+				Compatibilities: aws.StringSlice([]string{"FARGATE"}),
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Image: aws.String("nginx:alpine"),
+						LogConfiguration: &ecs.LogConfiguration{
+							LogDriver: aws.String("awslogs"),
+							Options: map[string]*string{
+								"awslogs-group":         aws.String("clu1"),
+								"awslogs-stream-prefix": aws.String("datfam"),
+								"awslogs-region":        aws.String("us-east-1"),
+								"awslogs-create-group":  aws.String("true"),
+							},
+						},
+						Name: aws.String("haxserver"),
+						PortMappings: []*ecs.PortMapping{
+							{ContainerPort: aws.Int64(80)},
+							{ContainerPort: aws.Int64(443)},
+						},
+					},
+				},
+				Cpu:                     aws.String("256"),
+				Family:                  aws.String("datfam"),
+				Memory:                  aws.String("512"),
+				ExecutionRoleArn:        aws.String("arn:aws:iam::12345678910:role/clu1-ecsTaskExecution"),
+				NetworkMode:             aws.String("awsvpc"),
+				RequiresAttributes:      []*ecs.Attribute{},
+				RequiresCompatibilities: aws.StringSlice([]string{"FARGATE"}),
+				Revision:                aws.Int64(1),
+				Status:                  aws.String("ACTIVE"),
+				TaskDefinitionArn:       aws.String("arn:aws:ecs:us-east-1:0123456789:task-definition/datfam:1"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newMockOrchestrator(t, tt.fields.org,
+				tt.fields.cwlerr, tt.fields.ecserr, tt.fields.iamerr,
+				tt.fields.rgtaerr, tt.fields.smerr, tt.fields.sderr)
+			got, _, err := o.processTaskTaskDefinitionCreate(tt.args.ctx, tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Orchestrator.processTaskTaskDefinitionCreate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Orchestrator.processTaskTaskDefinitionCreate() got = %v, want %v", got, tt.want)
+			}
+
+			// if !reflect.DeepEqual(got1, tt.want1) {
+			// 	t.Errorf("Orchestrator.processTaskTaskDefinitionCreate() got1 = %v, want %v", got1, tt.want1)
+			// }
+		})
+	}
+}
+
+func TestOrchestrator_processTaskDefinitionUpdate(t *testing.T) {
+	t.Log("testing processTaskDefinitionUpdate")
+
+	type fields struct {
+		org     string
+		cwlerr  error
+		ecserr  error
+		iamerr  error
+		rgtaerr error
+		smerr   error
+		sderr   error
+	}
+	type args struct {
+		ctx    context.Context
+		input  *ServiceOrchestrationUpdateInput
+		active *ServiceOrchestrationUpdateOutput
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantInput *ServiceOrchestrationUpdateInput
+	}{
+		{
+			name: "nil input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx:    context.TODO(),
+				input:  &ServiceOrchestrationUpdateInput{},
+				active: &ServiceOrchestrationUpdateOutput{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "example basic input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+				input: &ServiceOrchestrationUpdateInput{
+					ClusterName: "clu1",
+					TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+						ContainerDefinitions: []*ecs.ContainerDefinition{
+							{
+								Name:  aws.String("haxserver"),
+								Image: aws.String("nginx:alpine"),
+								PortMappings: []*ecs.PortMapping{
+									{ContainerPort: aws.Int64(80)},
+									{ContainerPort: aws.Int64(443)},
+								},
+							},
+						},
+						Cpu:    aws.String("256"),
+						Family: aws.String("datfam"),
+						Memory: aws.String("512"),
+					},
+					Tags: []*Tag{
+						{
+							Key:   aws.String("Application"),
+							Value: aws.String("derpderpderp"),
+						},
+					},
+					Service: &ecs.UpdateServiceInput{},
+				},
+				active: &ServiceOrchestrationUpdateOutput{},
+			},
+			wantInput: &ServiceOrchestrationUpdateInput{
+				ClusterName: "clu1",
+				TaskDefinition: &ecs.RegisterTaskDefinitionInput{
+					ContainerDefinitions: []*ecs.ContainerDefinition{
+						{
+							Name:  aws.String("haxserver"),
+							Image: aws.String("nginx:alpine"),
+							PortMappings: []*ecs.PortMapping{
+								{ContainerPort: aws.Int64(80)},
+								{ContainerPort: aws.Int64(443)},
+							},
+							LogConfiguration: &ecs.LogConfiguration{
+								LogDriver: aws.String("awslogs"),
+								Options: map[string]*string{
+									"awslogs-group":         aws.String("clu1"),
+									"awslogs-stream-prefix": aws.String("datfam"),
+									"awslogs-region":        aws.String("us-east-1"),
+									"awslogs-create-group":  aws.String("true"),
+								},
+							},
+						},
+					},
+					Cpu:                     aws.String("256"),
+					ExecutionRoleArn:        aws.String("arn:aws:iam::12345678910:role/clu1-ecsTaskExecution"),
+					Family:                  aws.String("datfam"),
+					Memory:                  aws.String("512"),
+					NetworkMode:             aws.String("awsvpc"),
+					RequiresCompatibilities: aws.StringSlice([]string{"FARGATE"}),
+				},
+				Tags: []*Tag{
+					{
+						Key:   aws.String("Application"),
+						Value: aws.String("derpderpderp"),
+					},
+				},
+				Service: &ecs.UpdateServiceInput{
+					TaskDefinition: aws.String("arn:aws:ecs:us-east-1:0123456789:task-definition/datfam:1"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newMockOrchestrator(t, tt.fields.org,
+				tt.fields.cwlerr, tt.fields.ecserr, tt.fields.iamerr,
+				tt.fields.rgtaerr, tt.fields.smerr, tt.fields.sderr)
+			if err := o.processTaskDefinitionUpdate(tt.args.ctx, tt.args.input, tt.args.active); (err != nil) != tt.wantErr {
+				t.Errorf("Orchestrator.processTaskDefinitionUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				if !reflect.DeepEqual(tt.args.input, tt.wantInput) {
+					t.Errorf("Orchestrator.processTaskDefinitionUpdate() input = %+v, wantInput %+v", tt.args.input, tt.wantInput)
+				}
+			}
+		})
+	}
+}
+
+func TestOrchestrator_defaultLogConfiguration(t *testing.T) {
+	t.Log("testing defaultLogConfiguration")
+
+	type fields struct {
+		org     string
+		cwlerr  error
+		ecserr  error
+		iamerr  error
+		rgtaerr error
+		smerr   error
+		sderr   error
+	}
+	type args struct {
+		ctx          context.Context
+		logGroup     string
+		streamPrefix string
+		tags         []*Tag
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *ecs.LogConfiguration
+		wantErr bool
+	}{
+		{
+			name: "empty inputs",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty inputs",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty log group",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx:          context.TODO(),
+				streamPrefix: "myprefix",
+				tags: []*Tag{
+					{
+						Key:   aws.String("key"),
+						Value: aws.String("value"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "example input",
+			fields: fields{
+				org: "myorg",
+			},
+			args: args{
+				ctx:          context.TODO(),
+				logGroup:     "mygroup",
+				streamPrefix: "myprefix",
+				tags: []*Tag{
+					{
+						Key:   aws.String("key"),
+						Value: aws.String("value"),
+					},
+				},
+			},
+			want: &ecs.LogConfiguration{
+				LogDriver: aws.String("awslogs"),
+				Options: map[string]*string{
+					"awslogs-group":         aws.String("mygroup"),
+					"awslogs-stream-prefix": aws.String("myprefix"),
+					"awslogs-region":        aws.String("us-east-1"),
+					"awslogs-create-group":  aws.String("true"),
+				},
+			},
+		},
+		{
+			name: "example input, log group exists",
+			fields: fields{
+				org:    "myorg",
+				cwlerr: awserr.New(cloudwatchlogs.ErrCodeResourceAlreadyExistsException, "exists", errors.New("exists")),
+			},
+			args: args{
+				ctx:          context.TODO(),
+				logGroup:     "mygroup",
+				streamPrefix: "myprefix",
+				tags: []*Tag{
+					{
+						Key:   aws.String("key"),
+						Value: aws.String("value"),
+					},
+				},
+			},
+			want: &ecs.LogConfiguration{
+				LogDriver: aws.String("awslogs"),
+				Options: map[string]*string{
+					"awslogs-group":         aws.String("mygroup"),
+					"awslogs-stream-prefix": aws.String("myprefix"),
+					"awslogs-region":        aws.String("us-east-1"),
+					"awslogs-create-group":  aws.String("true"),
+				},
+			},
+		},
+		{
+			name: "example input, other error",
+			fields: fields{
+				org:    "myorg",
+				cwlerr: errors.New("boom"),
+			},
+			args: args{
+				ctx:          context.TODO(),
+				logGroup:     "mygroup",
+				streamPrefix: "myprefix",
+				tags: []*Tag{
+					{
+						Key:   aws.String("key"),
+						Value: aws.String("value"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newMockOrchestrator(t, tt.fields.org,
+				tt.fields.cwlerr, tt.fields.ecserr, tt.fields.iamerr,
+				tt.fields.rgtaerr, tt.fields.smerr, tt.fields.sderr)
+			got, err := o.defaultLogConfiguration(tt.args.ctx, tt.args.logGroup, tt.args.streamPrefix, tt.args.tags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Orchestrator.defaultLogConfiguration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Orchestrator.defaultLogConfiguration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Create task definitions for later execution, ensuring required services are in place
* Remove some of the code that allows passing in existing resources on create since we don't use it and it adds confusion