### PR TITLE
Recreate repository credential secrets under the appropriate prefix if they live at the root

### DIFF
--- a/orchestration/iam_test.go
+++ b/orchestration/iam_test.go
@@ -23,8 +23,8 @@ var orch = Orchestrator{
 }
 
 var (
-	path     = "org/super-why"
-	testTime = time.Now()
+	pathPrefix = "org/super-why"
+	testTime   = time.Now()
 )
 
 var defaultPolicyDoc = im.PolicyDoc{
@@ -48,8 +48,8 @@ var defaultPolicyDoc = im.PolicyDoc{
 				"kms:Decrypt",
 			},
 			Resource: []string{
-				fmt.Sprintf("arn:aws:secretsmanager:*:*:secret:spinup/%s/*", path),
-				fmt.Sprintf("arn:aws:ssm:*:*:parameter/%s/*", path),
+				fmt.Sprintf("arn:aws:secretsmanager:*:*:secret:spinup/%s/*", pathPrefix),
+				fmt.Sprintf("arn:aws:ssm:*:*:parameter/%s/*", pathPrefix),
 				fmt.Sprintf("arn:aws:kms:*:*:key/%s", orch.IAM.DefaultKmsKeyID),
 			},
 		},
@@ -202,7 +202,7 @@ func TestOrchestrator_DefaultTaskExecutionPolicy(t *testing.T) {
 		IAM im.IAM
 	}
 	type args struct {
-		path string
+		pathPrefix string
 	}
 	tests := []struct {
 		name   string
@@ -218,7 +218,7 @@ func TestOrchestrator_DefaultTaskExecutionPolicy(t *testing.T) {
 				},
 			},
 			args: args{
-				path: path,
+				pathPrefix: pathPrefix,
 			},
 			want: defaultPolicyDoc,
 		},
@@ -228,7 +228,7 @@ func TestOrchestrator_DefaultTaskExecutionPolicy(t *testing.T) {
 			o := &Orchestrator{
 				IAM: tt.fields.IAM,
 			}
-			if got := o.DefaultTaskExecutionPolicy(tt.args.path); !reflect.DeepEqual(got, tt.want) {
+			if got := o.DefaultTaskExecutionPolicy(tt.args.pathPrefix); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Orchestrator.DefaultTaskExecutionPolicy() = %v, want %v", got, tt.want)
 			}
 		})
@@ -240,9 +240,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 		IAM im.IAM
 	}
 	type args struct {
-		ctx  context.Context
-		path string
-		role string
+		ctx        context.Context
+		pathPrefix string
+		role       string
 	}
 	tests := []struct {
 		name    string
@@ -252,7 +252,7 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "empty path",
+			name: "empty pathPrefix",
 			fields: fields{
 				IAM: im.IAM{
 					Service:         newMockIAMClient(t, nil),
@@ -260,9 +260,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "",
-				role: "role-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: "",
+				role:       "role-ecsTaskExecution",
 			},
 			wantErr: true,
 		},
@@ -275,14 +275,14 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: path,
-				role: "",
+				ctx:        context.TODO(),
+				pathPrefix: pathPrefix,
+				role:       "",
 			},
 			wantErr: true,
 		},
 		{
-			name: "example path",
+			name: "example pathPrefix",
 			fields: fields{
 				IAM: im.IAM{
 					Service:         newMockIAMClient(t, nil),
@@ -290,9 +290,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: path,
-				role: "super-why-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: pathPrefix,
+				role:       "super-why-ecsTaskExecution",
 			},
 			want: "arn:aws:iam::12345678910:role/super-why-ecsTaskExecution",
 		},
@@ -305,9 +305,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "missing",
-				role: "missing-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: "missing",
+				role:       "missing-ecsTaskExecution",
 			},
 			want: "arn:aws:iam::12345678910:role/missing-ecsTaskExecution",
 		},
@@ -320,9 +320,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "org/mr-rogers",
-				role: "mr-rogers-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: "org/mr-rogers",
+				role:       "mr-rogers-ecsTaskExecution",
 			},
 			want: "arn:aws:iam::12345678910:role/mr-rogers-ecsTaskExecution",
 		},
@@ -335,9 +335,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "org/missingpolicy",
-				role: "missingpolicy-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: "org/missingpolicy",
+				role:       "missingpolicy-ecsTaskExecution",
 			},
 			want: "arn:aws:iam::12345678910:role/missingpolicy-ecsTaskExecution",
 		},
@@ -350,9 +350,9 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "org/badpolicy",
-				role: "badpolicy-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: "org/badpolicy",
+				role:       "badpolicy-ecsTaskExecution",
 			},
 			wantErr: true,
 		},
@@ -362,7 +362,7 @@ func TestOrchestrator_DefaultTaskExecutionRole(t *testing.T) {
 			o := &Orchestrator{
 				IAM: tt.fields.IAM,
 			}
-			got, err := o.DefaultTaskExecutionRole(tt.args.ctx, tt.args.path, tt.args.role, nil)
+			got, err := o.DefaultTaskExecutionRole(tt.args.ctx, tt.args.pathPrefix, tt.args.role, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Orchestrator.DefaultTaskExecutionRole() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -379,9 +379,9 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 		IAM im.IAM
 	}
 	type args struct {
-		ctx  context.Context
-		path string
-		role string
+		ctx        context.Context
+		pathPrefix string
+		role       string
 	}
 	tests := []struct {
 		name    string
@@ -391,7 +391,7 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "empty path and role",
+			name: "empty pathPrefix and role",
 			fields: fields{
 				IAM: im.IAM{
 					Service:         newMockIAMClient(t, nil),
@@ -399,14 +399,14 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "",
-				role: "",
+				ctx:        context.TODO(),
+				pathPrefix: "",
+				role:       "",
 			},
 			wantErr: true,
 		},
 		{
-			name: "empty path",
+			name: "empty pathPrefix",
 			fields: fields{
 				IAM: im.IAM{
 					Service:         newMockIAMClient(t, nil),
@@ -414,9 +414,9 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "",
-				role: "super-why-ecsTaskExecution",
+				ctx:        context.TODO(),
+				pathPrefix: "",
+				role:       "super-why-ecsTaskExecution",
 			},
 			want: "arn:aws:iam::12345678910:role/super-why-ecsTaskExecution",
 		},
@@ -429,9 +429,9 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "org/super-why",
-				role: "",
+				ctx:        context.TODO(),
+				pathPrefix: "org/super-why",
+				role:       "",
 			},
 			wantErr: true,
 		},
@@ -444,9 +444,9 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				path: "org/super-why",
-				role: "testrole",
+				ctx:        context.TODO(),
+				pathPrefix: "org/super-why",
+				role:       "testrole",
 			},
 			want: "arn:aws:iam::12345678910:role/testrole",
 		},
@@ -456,7 +456,7 @@ func TestOrchestrator_createDefaultTaskExecutionRole(t *testing.T) {
 			o := &Orchestrator{
 				IAM: tt.fields.IAM,
 			}
-			got, err := o.createDefaultTaskExecutionRole(tt.args.ctx, tt.args.path, tt.args.role)
+			got, err := o.createDefaultTaskExecutionRole(tt.args.ctx, tt.args.pathPrefix, tt.args.role)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Orchestrator.defaultTaskExecutionRoleArn() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/orchestration/repositorycredentials.go
+++ b/orchestration/repositorycredentials.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	log "github.com/sirupsen/logrus"
@@ -176,23 +177,38 @@ func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, i
 	inputCredentials := input.Credentials
 	log.Debugf("input credentials %+v", inputCredentials)
 
+	org := ""
+	if o.Org != "" {
+		org = o.Org + "/"
+	}
+
+	cluster := ""
+	if input.ClusterName != "" {
+		cluster = input.ClusterName + "/"
+	} else if input.Service != nil && input.Service.Cluster != nil {
+		cluster = aws.StringValue(input.Service.Cluster) + "/"
+	}
+
+	// prefix is spinup/ss/spinup-000001/
+	prefix := "spinup/" + org + cluster
+
 	client := o.SecretsManager
 	creds := make(map[string]interface{}, len(input.Credentials))
+	markedForDeletion := []string{}
 	for _, cd := range input.TaskDefinition.ContainerDefinitions {
 		containerName := aws.StringValue(cd.Name)
 		log.Debugf("processing container definition %s repository credentials", containerName)
 
 		activeRepositoryCredential, hasActiveRepositoryCredential := activeRepositoryCredentials[containerName]
-		_, hasInputRepositoryCredential := inputRepositoryCredentials[containerName]
+		inputRepositoryCredentials, hasInputRepositoryCredential := inputRepositoryCredentials[containerName]
 		inputCredential, hasInputCredential := inputCredentials[containerName]
 
 		// if there are active repository credentials and no input repository credentials or input credentials,
 		// delete the secret at the active repository credentials
 		if hasActiveRepositoryCredential && !hasInputRepositoryCredential && !hasInputCredential {
-			log.Warnf("active %s container has repository credentials (%s) but updated definition doesn't, deleting credentials", containerName, activeRepositoryCredential)
-			if _, err := client.DeleteSecret(ctx, activeRepositoryCredential, 0); err != nil {
-				return err
-			}
+			log.Warnf("active %s container has repository credentials (%s) but updated definition doesn't, marking credentials for deletion", containerName, activeRepositoryCredential)
+			markedForDeletion = append(markedForDeletion, activeRepositoryCredential)
+
 			// if there are active repository credentials, set the input repository credentials to the active repository credentials
 		} else if hasActiveRepositoryCredential {
 			log.Debugf("overriding input repository credentials with active repository credentials")
@@ -200,6 +216,42 @@ func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, i
 				CredentialsParameter: aws.String(activeRepositoryCredential),
 			}
 			hasInputRepositoryCredential = true
+			inputRepositoryCredentials = activeRepositoryCredential
+		}
+
+		// if the input contains repository credentials ARN, parse the ARN to see if it contains our prefix
+		// if it doesn't contain the prefix, get the value and set the credentials to be created new and
+		// mark the original root level credentials for deletion
+		if hasInputRepositoryCredential {
+			parsedArn, err := arn.Parse(inputRepositoryCredentials)
+			if err != nil {
+				return err
+			}
+
+			if !strings.HasPrefix(parsedArn.Resource, "secret:"+prefix) {
+				log.Warnf("secret %s lives at the root", inputRepositoryCredentials)
+
+				// if we don't have any new credentials from the user, set them up from the existing secret
+				if !hasInputCredential {
+					secretValue, err := o.SecretsManager.GetValue(ctx, inputRepositoryCredentials)
+					if err != nil {
+						return err
+					}
+
+					inputCredential = &secretsmanager.CreateSecretInput{
+						Name:         secretValue.Name,
+						SecretString: secretValue.SecretString,
+					}
+					hasInputCredential = true
+				}
+
+				// clear the input credentials arn from the task definition input to create a new secret
+				hasInputRepositoryCredential = false
+				cd.RepositoryCredentials = nil
+
+				log.Warnf("marking root level secret for deletion %s", inputRepositoryCredentials)
+				markedForDeletion = append(markedForDeletion, inputRepositoryCredentials)
+			}
 		}
 
 		// if there is an input credential and an input repository credential, update the input repository
@@ -233,19 +285,7 @@ func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, i
 			}
 			inputCredential.Tags = smTags
 
-			org := ""
-			if o.Org != "" {
-				org = o.Org + "/"
-			}
-
-			cluster := ""
-			if input.ClusterName != "" {
-				cluster = input.ClusterName + "/"
-			} else if input.Service != nil && input.Service.Cluster != nil {
-				cluster = aws.StringValue(input.Service.Cluster) + "/"
-			}
-
-			inputCredential.Name = aws.String("spinup/" + org + cluster + aws.StringValue(inputCredential.Name))
+			inputCredential.Name = aws.String(prefix + aws.StringValue(inputCredential.Name))
 
 			out, err := client.CreateSecret(ctx, inputCredential)
 			if err != nil {
@@ -267,6 +307,13 @@ func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, i
 	}
 
 	log.Debugf("processed update of repository credentials: %+v", creds)
+
+	for _, m := range markedForDeletion {
+		log.Infof("deleting secrets mamanger secret %s (marked for deletion)", m)
+		if _, err := client.DeleteSecret(ctx, m, 0); err != nil {
+			return err
+		}
+	}
 
 	active.Credentials = creds
 
@@ -302,6 +349,7 @@ func (o *Orchestrator) createRepostitoryCredentials(ctx context.Context, prefix 
 	return creds, nil
 }
 
+// containterDefinitionCredsMap maps the container definition names to the ARN
 func containterDefinitionCredsMap(containerDefinitions []*ecs.ContainerDefinition) map[string]string {
 	creds := map[string]string{}
 	for _, cd := range containerDefinitions {

--- a/secretsmanager/secrets.go
+++ b/secretsmanager/secrets.go
@@ -90,6 +90,24 @@ func (s *SecretsManager) GetSecretMetaDataWithFilter(ctx context.Context, id str
 	return nil, apierror.New(apierror.ErrNotFound, "no secret matching filter", nil)
 }
 
+// GetValue gets the secret value from secretsmanager
+func (s *SecretsManager) GetValue(ctx context.Context, id string) (*secretsmanager.GetSecretValueOutput, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting secretsmanager secret value %s ", id)
+
+	out, err := s.Service.GetSecretValueWithContext(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(id),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to get secret value", err)
+	}
+
+	return out, nil
+}
+
 // DeleteSecret marks a secret for deletion. Optionally, the secret can be forcefully deleted.
 func (s *SecretsManager) DeleteSecret(ctx context.Context, id string, window int64) (*secretsmanager.DeleteSecretOutput, error) {
 	if id == "" {


### PR DESCRIPTION
* Currently we permit access to secrets under the spinup/org/spaceid path in the task execution role
* Some old container services have repository credentials secrets without the prefix in secretsmanager
* This recreates and cleans up secrets that live in the root if they are found during an update, it will use passed credentials to create the new secret if they exist, otherwise they will use the secret string in the root level secret