### PR TITLE
Support for updating task definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,40 +43,42 @@ This API provides simple restful API access to Amazon's ECS Fargate service.
     - [Get a managed task definitions in a cluster](#get-a-managed-task-definitions-in-a-cluster)
       - [Request](#request-6)
       - [Response](#response-6)
-  - [SSM Parameters](#ssm-parameters-1)
-    - [Create a param](#create-a-param)
+    - [Run a managed task definition in a cluster](#run-a-managed-task-definition-in-a-cluster)
       - [Request](#request-7)
       - [Response](#response-7)
-    - [List parameters](#list-parameters)
-      - [Response](#response-8)
-    - [Show a parameter](#show-a-parameter)
-      - [Response](#response-9)
-    - [Delete a parameter](#delete-a-parameter)
-      - [Response](#response-10)
-    - [Delete all parameters in a prefix](#delete-all-parameters-in-a-prefix)
-      - [Response](#response-11)
-    - [Update a parameter](#update-a-parameter)
+  - [SSM Parameters](#ssm-parameters-1)
+    - [Create a param](#create-a-param)
       - [Request](#request-8)
+      - [Response](#response-8)
+    - [List parameters](#list-parameters)
+      - [Response](#response-9)
+    - [Show a parameter](#show-a-parameter)
+      - [Response](#response-10)
+    - [Delete a parameter](#delete-a-parameter)
+      - [Response](#response-11)
+    - [Delete all parameters in a prefix](#delete-all-parameters-in-a-prefix)
       - [Response](#response-12)
-  - [Secrets](#secrets)
-    - [Create a secret](#create-a-secret)
+    - [Update a parameter](#update-a-parameter)
       - [Request](#request-9)
       - [Response](#response-13)
-    - [List secrets](#list-secrets)
-      - [Response](#response-14)
-    - [Show a secret](#show-a-secret)
-      - [Response](#response-15)
-    - [Delete a secret](#delete-a-secret)
-      - [Response](#response-16)
-    - [Update a secret](#update-a-secret)
+  - [Secrets](#secrets)
+    - [Create a secret](#create-a-secret)
       - [Request](#request-10)
+      - [Response](#response-14)
+    - [List secrets](#list-secrets)
+      - [Response](#response-15)
+    - [Show a secret](#show-a-secret)
+      - [Response](#response-16)
+    - [Delete a secret](#delete-a-secret)
       - [Response](#response-17)
-    - [List load balancers (target groups) for a space](#list-load-balancers-target-groups-for-a-space)
+    - [Update a secret](#update-a-secret)
+      - [Request](#request-11)
       - [Response](#response-18)
+    - [List load balancers (target groups) for a space](#list-load-balancers-target-groups-for-a-space)
+      - [Response](#response-19)
   - [Development](#development)
   - [Author](#author)
   - [License](#license)
-
 
 ## Endpoint Summary
 
@@ -106,6 +108,7 @@ POST /v1/ecs/{account}/taskdefs
 GET /v1/ecs/{account}/clusters/{cluster}/taskdefs
 DELETE /v1/ecs/{account}/clusters/{cluster}/taskdefs/{taskdef}
 GET /v1/ecs/{account}/clusters/{cluster}/taskdefs/{taskdef}
+POST /v1/ecs/{account}/clusters/{cluster}/taskdefs/{taskdef}/tasks
 
 // Secrets handlers
 GET /v1/ecs/{account}/secrets
@@ -596,7 +599,41 @@ GET /v1/ecs/{account}/cluster/{cluster}/taskdefs/{taskdef}
 
 #### Response
 
-The response is the service body.
+The response is the taskdef body.
+
+```json
+TODO
+```
+
+| Response Code                 | Definition                               |
+| ----------------------------- | -----------------------------------------|
+| **200 OK**                    | okay                                     |
+| **400 Bad Request**           | badly formed request                     |
+| **404 Not Found**             | account, cluster or taskdef wasn't found |
+| **500 Internal Server Error** | a server error occurred                  |
+
+
+### Run a managed task definition in a cluster
+
+Runs a task definition
+
+#### Request
+
+POST /v1/ecs/{account}/cluster/{cluster}/taskdefs/{taskdef}/tasks
+
+The input for running a task uses the RunTaskInput and overrides with our standard required values.  Tags are propagated from the Task Definition.
+
+[RunTaskInput](https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#RunTaskInput)
+
+```json
+{
+    "Count": 1
+}
+```
+
+#### Response
+
+The response is the tasks output and any failures.
 
 ```json
 TODO

--- a/api/handlers_services.go
+++ b/api/handlers_services.go
@@ -239,7 +239,7 @@ func (s *server) ServiceShowHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		tdOutput, _, err := ecsService.GetTaskDefinition(r.Context(), serviceOutput.TaskDefinition)
+		tdOutput, _, err := ecsService.GetTaskDefinition(r.Context(), serviceOutput.TaskDefinition, false)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/handlers_taskdef.go
+++ b/api/handlers_taskdef.go
@@ -224,3 +224,50 @@ func (s *server) TaskDefUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(j)
 }
+
+func (s *server) TaskDefRunHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+	taskdef := vars["taskdef"]
+
+	orchestrator, err := s.newOrchestrator(account)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+
+	log.Debugf("run taskdef orchestration request body:\n%s", body)
+
+	var req orchestration.TaskDefRunOrchestrationInput
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
+		log.Error("cannot Decode body into create taskdef input")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	log.Debugf("decoded request into taskdef orchestration request: %+v", req)
+
+	output, err := orchestrator.RunTaskDef(r.Context(), cluster, taskdef, req)
+	if err != nil {
+		log.Errorf("error in creating taskdef orchestration: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}

--- a/api/handlers_taskdef.go
+++ b/api/handlers_taskdef.go
@@ -61,6 +61,7 @@ func (s *server) TaskDefCreateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
+// TaskDefDeleteHandler handles deleting task definitions and related resources
 func (s *server) TaskDefDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -107,6 +108,7 @@ func (s *server) TaskDefDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
+// TaskDefListHandler handles getting a list of task definitions in a cluster
 func (s *server) TaskDefListHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -141,6 +143,7 @@ func (s *server) TaskDefListHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
+// TaskDefShowHandler handles getting the details about a task definition in a cluster
 func (s *server) TaskDefShowHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -176,6 +179,7 @@ func (s *server) TaskDefShowHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
+// TaskDefUpdateHandler handles updating a task definition in a cluster
 func (s *server) TaskDefUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)

--- a/api/handlers_taskdef.go
+++ b/api/handlers_taskdef.go
@@ -39,7 +39,7 @@ func (s *server) TaskDefCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("decoded request into taskdef orchestration request:\n %+v", req)
+	log.Debugf("decoded request into taskdef orchestration request: %+v", req)
 
 	output, err := orchestrator.CreateTaskDef(r.Context(), &req)
 	if err != nil {
@@ -159,6 +159,55 @@ func (s *server) TaskDefShowHandler(w http.ResponseWriter, r *http.Request) {
 	output, err := orchestrator.GetTaskDef(r.Context(), cluster, taskdef)
 	if err != nil {
 		log.Errorf("error in taskdef get orchestration: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+func (s *server) TaskDefUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+	taskdef := vars["taskdef"]
+
+	log.Debugf("updating taskdef %s/%s/%s", account, cluster, taskdef)
+
+	orchestrator, err := s.newOrchestrator(account)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+
+	log.Debugf("update taskdef orchestration request body: %s", body)
+
+	var req orchestration.TaskDefUpdateOrchestrationInput
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
+		log.Error("cannot Decode body into update taskdef input")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	log.Debugf("decoded request into taskdef orchestration request:\n %+v", req)
+
+	output, err := orchestrator.UpdateTaskDef(r.Context(), cluster, taskdef, &req)
+	if err != nil {
+		log.Errorf("error in creating taskdef orchestration: %s", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return

--- a/api/routes.go
+++ b/api/routes.go
@@ -37,6 +37,8 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefShowHandler).Methods(http.MethodGet)
 
+	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}/tasks", s.TaskDefRunHandler).Methods(http.MethodPost)
+
 	// Secrets handlers
 	api.HandleFunc("/{account}/secrets", s.SecretListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/secrets", s.SecretCreateHandler).Methods(http.MethodPost)

--- a/api/routes.go
+++ b/api/routes.go
@@ -33,6 +33,7 @@ func (s *server) routes() {
 	// TaskDef handlers
 	api.HandleFunc("/{account}/taskdefs", s.TaskDefCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs", s.TaskDefListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefUpdateHandler).Methods(http.MethodPut)
 	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/clusters/{cluster}/taskdefs/{taskdef}", s.TaskDefShowHandler).Methods(http.MethodGet)
 

--- a/ecs/taskdefinition.go
+++ b/ecs/taskdefinition.go
@@ -46,18 +46,22 @@ func (e *ECS) DeleteTaskDefinition(ctx context.Context, taskdefinition *string) 
 }
 
 // GetTaskDefinition gets a task definition with context by name
-func (e *ECS) GetTaskDefinition(ctx context.Context, taskdefinition *string) (*ecs.TaskDefinition, []*ecs.Tag, error) {
+func (e *ECS) GetTaskDefinition(ctx context.Context, taskdefinition *string, tags bool) (*ecs.TaskDefinition, []*ecs.Tag, error) {
 	if aws.StringValue(taskdefinition) == "" {
 		return nil, nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
 	log.Infof("getting details about task definition '%s'", aws.StringValue(taskdefinition))
 
-	output, err := e.Service.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
-		Include:        aws.StringSlice([]string{"TAGS"}),
+	input := ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: taskdefinition,
-	})
+	}
 
+	if tags {
+		input.Include = aws.StringSlice([]string{"TAGS"})
+	}
+
+	output, err := e.Service.DescribeTaskDefinitionWithContext(ctx, &input)
 	if err != nil {
 		return nil, nil, ErrCode("failed to get task definition", err)
 	}

--- a/ecs/taskdefinition_test.go
+++ b/ecs/taskdefinition_test.go
@@ -165,7 +165,7 @@ func TestCreateTaskDefinition(t *testing.T) {
 
 func TestGetTaskDefinition(t *testing.T) {
 	client := ECS{Service: &mockECSClient{t: t}}
-	td, _, err := client.GetTaskDefinition(context.TODO(), goodTd1.TaskDefinitionArn)
+	td, _, err := client.GetTaskDefinition(context.TODO(), goodTd1.TaskDefinitionArn, false)
 	if err != nil {
 		t.Fatal("expected no error from describe task definition, got:", err)
 	}
@@ -175,24 +175,24 @@ func TestGetTaskDefinition(t *testing.T) {
 	}
 
 	// test nil task definition
-	_, _, err = client.GetTaskDefinition(context.TODO(), nil)
+	_, _, err = client.GetTaskDefinition(context.TODO(), nil, false)
 	if err == nil {
 		t.Fatal("expected error from create task definition, got nil")
 	}
 
 	// test empty task definition
-	_, _, err = client.GetTaskDefinition(context.TODO(), aws.String(""))
+	_, _, err = client.GetTaskDefinition(context.TODO(), aws.String(""), false)
 	if err == nil {
 		t.Fatal("expected error from create task definition, got nil")
 	}
 
-	_, _, err = client.GetTaskDefinition(context.TODO(), aws.String("somenotfoundtd"))
+	_, _, err = client.GetTaskDefinition(context.TODO(), aws.String("somenotfoundtd"), false)
 	if err == nil {
 		t.Fatal("expected error from GetTaskDefinition, got:", err)
 	}
 
 	// test an error task definition
-	td, _, err = client.GetTaskDefinition(context.TODO(), aws.String("badtd"))
+	td, _, err = client.GetTaskDefinition(context.TODO(), aws.String("badtd"), false)
 	if err == nil {
 		t.Fatal("expected error from create task definition, got", err, td)
 	}

--- a/orchestration/cluster.go
+++ b/orchestration/cluster.go
@@ -29,8 +29,8 @@ func (o *Orchestrator) processServiceCluster(ctx context.Context, input *Service
 	return cluster, rbfunc, nil
 }
 
-// processTaskCluster ensures the cluster exists for a task definition
-func (o *Orchestrator) processTaskCluster(ctx context.Context, input *TaskDefCreateOrchestrationInput) (*ecs.Cluster, rollbackFunc, error) {
+// processTaskDefCluster ensures the cluster exists for a task definition
+func (o *Orchestrator) processTaskDefCluster(ctx context.Context, input *TaskDefCreateOrchestrationInput) (*ecs.Cluster, rollbackFunc, error) {
 	if input.Cluster == nil {
 		return nil, defaultRbfunc("processTaskCluster"), apierror.New(apierror.ErrBadRequest, "cluster cannot be empty", nil)
 	}

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -195,10 +195,10 @@ func TestProcessCluster(t *testing.T) {
 	}
 }
 
-func TestProcessTaskCluster(t *testing.T) {
+func TestProcessTaskDefCluster(t *testing.T) {
 	orchestrator := newMockOrchestrator(t, "myorg", nil, nil, nil, nil, nil, nil)
 
-	if _, _, err := orchestrator.processTaskCluster(context.TODO(), &TaskDefCreateOrchestrationInput{}); err == nil {
+	if _, _, err := orchestrator.processTaskDefCluster(context.TODO(), &TaskDefCreateOrchestrationInput{}); err == nil {
 		t.Error("expected error for missing cluster, got nil")
 	}
 
@@ -212,7 +212,7 @@ func TestProcessTaskCluster(t *testing.T) {
 			},
 		}
 
-		out, _, err := orchestrator.processTaskCluster(context.TODO(), &input)
+		out, _, err := orchestrator.processTaskDefCluster(context.TODO(), &input)
 		if err != nil {
 			t.Errorf("expected nil error, got %s", err)
 		}
@@ -232,7 +232,7 @@ func TestProcessTaskCluster(t *testing.T) {
 			ClusterName: aws.String("cluster0"),
 		},
 	}
-	if _, _, err := orchestrator.processTaskCluster(context.TODO(), &input); err == nil {
+	if _, _, err := orchestrator.processTaskDefCluster(context.TODO(), &input); err == nil {
 		t.Error("expected error, got nil")
 	}
 }

--- a/orchestration/orchestration_service.go
+++ b/orchestration/orchestration_service.go
@@ -213,7 +213,7 @@ func (o *Orchestrator) DeleteService(ctx context.Context, input *ServiceDeleteIn
 			}
 
 			// get the active task definition to find the task definition family
-			taskDefinition, _, err := o.ECS.GetTaskDefinition(cleanupCtx, service.TaskDefinition)
+			taskDefinition, _, err := o.ECS.GetTaskDefinition(cleanupCtx, service.TaskDefinition, false)
 			if err != nil {
 				log.Errorf("failed to get active task definition '%s': %s", aws.StringValue(service.TaskDefinition), err)
 			} else {
@@ -224,7 +224,7 @@ func (o *Orchestrator) DeleteService(ctx context.Context, input *ServiceDeleteIn
 				} else {
 					for _, revision := range taskDefinitionRevisions {
 
-						taskDefinition, _, err := o.ECS.GetTaskDefinition(cleanupCtx, aws.String(revision))
+						taskDefinition, _, err := o.ECS.GetTaskDefinition(cleanupCtx, aws.String(revision), false)
 						if err != nil {
 							log.Errorf("failed to get task definition revisions '%s' to delete: %s", revision, err)
 							continue
@@ -293,7 +293,7 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 	active.Service = svc
 
 	// get the active task def
-	tdef, _, err := o.ECS.GetTaskDefinition(ctx, active.Service.TaskDefinition)
+	tdef, _, err := o.ECS.GetTaskDefinition(ctx, active.Service.TaskDefinition, false)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestration/orchestration_taskdef.go
+++ b/orchestration/orchestration_taskdef.go
@@ -138,6 +138,8 @@ func (o *Orchestrator) UpdateTaskDef(ctx context.Context, cluster, family string
 
 	log.Debugf("got task definition %+v", taskdef)
 
+	output.TaskDefinition = taskdef
+
 	if input.TaskDefinition != nil {
 		// if the tags are empty for the task definition, apply the existing tags
 		if input.TaskDefinition.Tags == nil {

--- a/orchestration/orchestration_taskdef.go
+++ b/orchestration/orchestration_taskdef.go
@@ -123,6 +123,7 @@ func (o *Orchestrator) CreateTaskDef(ctx context.Context, input *TaskDefCreateOr
 	return output, nil
 }
 
+// UpdateTaskDef takes the task definition update input and orchestrates the update for a task definition and related resources
 func (o *Orchestrator) UpdateTaskDef(ctx context.Context, cluster, family string, input *TaskDefUpdateOrchestrationInput) (*TaskDefUpdateOrchestrationOutput, error) {
 	output := &TaskDefUpdateOrchestrationOutput{}
 
@@ -272,6 +273,7 @@ func (o *Orchestrator) deleteTaskDefinitionRevision(ctx context.Context, revisio
 	return errors
 }
 
+// ListTaskDefs gets a list of task definitions in a cluster using tags
 func (o *Orchestrator) ListTaskDefs(ctx context.Context, cluster string) ([]string, error) {
 	log.Infof("listing task definitions in cluster '%s'", cluster)
 
@@ -326,6 +328,7 @@ func (o *Orchestrator) ListTaskDefs(ctx context.Context, cluster string) ([]stri
 	return taskDefinitionFamilies, nil
 }
 
+// GetTaskDef gets the details about a task definition
 func (o *Orchestrator) GetTaskDef(ctx context.Context, cluster, family string) (*TaskDefShowOutput, error) {
 	if cluster == "" || family == "" {
 		return nil, errors.New("cluster and task def family are required")

--- a/orchestration/repositorycredentials.go
+++ b/orchestration/repositorycredentials.go
@@ -160,6 +160,8 @@ func (o *Orchestrator) processRepositoryCredentialsUpdate(ctx context.Context, i
 	return nil
 }
 
+// processTaskDefRepositoryCredentialsUpdate processes the repository credentials in a task definition
+// TODO container defs that are removed dont trigger the secret to get removed.
 func (o *Orchestrator) processTaskDefRepositoryCredentialsUpdate(ctx context.Context, input *TaskDefUpdateOrchestrationInput, active *TaskDefUpdateOrchestrationOutput) error {
 	if active == nil || active.TaskDefinition == nil || active.TaskDefinition.ContainerDefinitions == nil {
 		return errors.New("cannot process nil active input")

--- a/orchestration/repositorycredentials_test.go
+++ b/orchestration/repositorycredentials_test.go
@@ -141,7 +141,7 @@ func TestProcessRepositoryCredentialsCreate(t *testing.T) {
 
 }
 
-func TestProcessTaskRepositoryCredentialsCreate(t *testing.T) {
+func TestProcessTaskDefRepositoryCredentialsCreate(t *testing.T) {
 	credentialsMapIn := map[string]*secretsmanager.CreateSecretInput{
 		"container1": {
 			Name:         aws.String("container1"),
@@ -170,22 +170,22 @@ func TestProcessTaskRepositoryCredentialsCreate(t *testing.T) {
 		SecretsManager: sm.SecretsManager{Service: &mockSMClient{t: t}},
 		Org:            "mock",
 	}
-	out, _, err := o.processTaskRepositoryCredentialsCreate(context.TODO(), &TaskDefCreateOrchestrationInput{})
+	out, _, err := o.processTaskDefRepositoryCredentialsCreate(context.TODO(), &TaskDefCreateOrchestrationInput{})
 	if err != nil {
-		t.Errorf("expected nil error for processTaskRepositoryCredentialsCreate, got %s", err)
+		t.Errorf("expected nil error for processTaskDefRepositoryCredentialsCreate, got %s", err)
 	}
 
 	if out != nil {
 		t.Errorf("expected nil output for empty repository credentials, got %+v", out)
 	}
 
-	out, _, err = o.processTaskRepositoryCredentialsCreate(context.TODO(), &TaskDefCreateOrchestrationInput{
+	out, _, err = o.processTaskDefRepositoryCredentialsCreate(context.TODO(), &TaskDefCreateOrchestrationInput{
 		Cluster:        &ecs.CreateClusterInput{ClusterName: aws.String("getAClu1")},
 		TaskDefinition: tdInput,
 		Credentials:    credentialsMapIn,
 	})
 	if err != nil {
-		t.Errorf("expected nil error for processTaskRepositoryCredentialsCreate, got %s", err)
+		t.Errorf("expected nil error for processTaskDefRepositoryCredentialsCreate, got %s", err)
 	}
 
 	if !reflect.DeepEqual(credentialsMapOut, out) {

--- a/orchestration/taskdefinition_test.go
+++ b/orchestration/taskdefinition_test.go
@@ -210,7 +210,7 @@ func TestOrchestrator_processTaskDefinitionCreate(t *testing.T) {
 	}
 }
 
-func TestOrchestrator_processTaskTaskDefinitionCreate(t *testing.T) {
+func TestOrchestrator_processTaskDefTaskDefinitionCreate(t *testing.T) {
 	t.Log("testing processTaskTaskDefinitionCreate")
 
 	type fields struct {
@@ -329,17 +329,17 @@ func TestOrchestrator_processTaskTaskDefinitionCreate(t *testing.T) {
 			o := newMockOrchestrator(t, tt.fields.org,
 				tt.fields.cwlerr, tt.fields.ecserr, tt.fields.iamerr,
 				tt.fields.rgtaerr, tt.fields.smerr, tt.fields.sderr)
-			got, _, err := o.processTaskTaskDefinitionCreate(tt.args.ctx, tt.args.input)
+			got, _, err := o.processTaskDefTaskDefinitionCreate(tt.args.ctx, tt.args.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Orchestrator.processTaskTaskDefinitionCreate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Orchestrator.processTaskDefTaskDefinitionCreate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Orchestrator.processTaskTaskDefinitionCreate() got = %v, want %v", got, tt.want)
+				t.Errorf("Orchestrator.processTaskDefTaskDefinitionCreate() got = %v, want %v", got, tt.want)
 			}
 
 			// if !reflect.DeepEqual(got1, tt.want1) {
-			// 	t.Errorf("Orchestrator.processTaskTaskDefinitionCreate() got1 = %v, want %v", got1, tt.want1)
+			// 	t.Errorf("Orchestrator.processTaskDefTaskDefinitionCreate() got1 = %v, want %v", got1, tt.want1)
 			// }
 		})
 	}

--- a/orchestration/tasks.go
+++ b/orchestration/tasks.go
@@ -1,0 +1,78 @@
+package orchestration
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	log "github.com/sirupsen/logrus"
+)
+
+type Task struct {
+	*ecs.Task
+	Revision int64
+}
+
+type TaskOutput struct {
+	Tasks    []*Task
+	Failures []*ecs.Failure
+}
+
+func (o *Orchestrator) GetTask(ctx context.Context, cluster, task string) (*TaskOutput, error) {
+	if task == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "task cannot be empty", nil)
+	}
+
+	out, err := o.ECS.GetTasks(ctx, &ecs.DescribeTasksInput{
+		Cluster: aws.String(cluster),
+		Tasks:   aws.StringSlice([]string{task}),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := toTaskOutput(out.Tasks, out.Failures)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// toTaskOutput adds the revision to the tasks
+func toTaskOutput(tasks []*ecs.Task, failures []*ecs.Failure) (*TaskOutput, error) {
+	output := &TaskOutput{Failures: failures}
+	ts := make([]*Task, 0, len(tasks))
+	for _, t := range tasks {
+		revision := int64(0)
+		tdArn, err := arn.Parse(aws.StringValue(t.TaskDefinitionArn))
+		if err != nil {
+			log.Errorf("failed to parse taskdefinition ARN: '%s': %s", aws.StringValue(t.TaskDefinitionArn), err)
+		} else {
+			log.Debugf("splitting task def arn resource %s", tdArn.Resource)
+			ss := strings.Split(tdArn.Resource, ":")
+			if len(ss) > 1 {
+				s := ss[len(ss)-1]
+				si, err := strconv.Atoi(s)
+				if err != nil {
+					log.Errorf("failed to parse revision '%s' as number for arn resource '%s': %s", s, tdArn.Resource, err)
+				}
+				revision = int64(si)
+			}
+		}
+
+		ts = append(ts, &Task{
+			Task:     t,
+			Revision: revision,
+		})
+	}
+	output.Tasks = ts
+
+	log.Debugf("returning output from running tasks: %+v", output)
+
+	return output, nil
+}

--- a/orchestration/tasks_test.go
+++ b/orchestration/tasks_test.go
@@ -1,0 +1,72 @@
+package orchestration
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+func Test_toTaskOutput(t *testing.T) {
+	type args struct {
+		tasks    []*ecs.Task
+		failures []*ecs.Failure
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *TaskOutput
+		wantErr bool
+	}{
+		{
+			name: "nil input",
+			args: args{},
+			want: &TaskOutput{
+				Tasks: []*Task{},
+			},
+		},
+		{
+			name: "tasks input",
+			args: args{
+				tasks: []*ecs.Task{
+					{TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/td1:1")},
+					{TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/td2:2")},
+					{TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/td3:3")},
+				},
+			},
+			want: &TaskOutput{
+				Tasks: []*Task{
+					{&ecs.Task{TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/td1:1")}, 1},
+					{&ecs.Task{TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/td2:2")}, 2},
+					{&ecs.Task{TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:1234567890:task-definition/td3:3")}, 3},
+				},
+			},
+		},
+		{
+			name: "bad arn input",
+			args: args{
+				tasks: []*ecs.Task{
+					{TaskDefinitionArn: aws.String("i-am-not-an-arn")},
+				},
+			},
+			want: &TaskOutput{
+				Tasks: []*Task{
+					{&ecs.Task{TaskDefinitionArn: aws.String("i-am-not-an-arn")}, 0},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toTaskOutput(tt.args.tasks, tt.args.failures)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toTaskOutput() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toTaskOutput() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Add the endpoint for updating task definitions.  
* Split out sharable code for processing repository credentials and start to refactor it into smaller pieces where possible.  It's still a mess and way more complex than I would like.
* Fixed an issue where the new `spinup:category` tag was being applied to space level dependent resources (clusters, roles)
