### PR TITLE
Small refactor for tagging of task/service resources

### DIFF
--- a/orchestration/cloudwatchlogs.go
+++ b/orchestration/cloudwatchlogs.go
@@ -1,0 +1,45 @@
+package orchestration
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	log "github.com/sirupsen/logrus"
+)
+
+// cloudwatchLogGroups collects all of the log group arns for the passed container definitions
+func (o *Orchestrator) cloudwatchLogGroups(ctx context.Context, containerDefs []*ecs.ContainerDefinition) ([]string, error) {
+	logGroupArns := []string{}
+	logGroupNames := map[string]struct{}{}
+
+	for _, cd := range containerDefs {
+		if cd.LogConfiguration != nil {
+			logGroupName, ok := cd.LogConfiguration.Options["awslogs-group"]
+			if !ok {
+				continue
+			}
+
+			lgn := aws.StringValue(logGroupName)
+
+			// if the log group has already been fetched, skip it
+			if _, ok := logGroupNames[lgn]; ok {
+				continue
+			}
+			logGroupNames[lgn] = struct{}{}
+
+			lg, err := o.CloudWatchLogs.GetLogGroup(ctx, lgn)
+			if err != nil {
+				log.Errorf("failed to get details about log group")
+				continue
+			}
+
+			// log group ARNs are returned with a :* on the end, remove it if it exists
+			cleanArn := strings.TrimSuffix(aws.StringValue(lg.Arn), ":*")
+			logGroupArns = append(logGroupArns, cleanArn)
+		}
+	}
+
+	return logGroupArns, nil
+}

--- a/orchestration/tags.go
+++ b/orchestration/tags.go
@@ -1,12 +1,18 @@
 package orchestration
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	log "github.com/sirupsen/logrus"
 )
 
 // ecsTags takes a slice of tags and converts them to ECS tags
@@ -54,4 +60,171 @@ func cleanTags(org, spaceid string, tags []*Tag) ([]*Tag, error) {
 	}
 
 	return cleanTags, nil
+}
+
+// sharedResourceTags generates a taglist for resources that are shared (clusters, roles, etc)
+func sharedResourceTags(name string, tags []*Tag) map[string]*string {
+	output := map[string]*string{}
+
+	if name != "" {
+		output["Name"] = aws.String(name)
+	}
+
+	for _, t := range tags {
+		key := aws.StringValue(t.Key)
+		if strings.ToLower(key) != "spinup:category" && strings.ToLower(key) != "name" {
+			output[key] = t.Value
+		}
+	}
+
+	return output
+}
+
+// specificResourceTags generates a taglist for resources that are specific to a resource in spinup
+func specificResourceTags(tags []*Tag) map[string]*string {
+	output := map[string]*string{}
+
+	for _, t := range tags {
+		output[aws.StringValue(t.Key)] = t.Value
+	}
+
+	return output
+}
+
+// roleTags generates a taglist for IAM roles which are still unique and special snowflakes (and dont't
+// support the resourcegroupstaggingapi)
+func roleTags(name string, tags []*Tag) []*iam.Tag {
+	output := []*iam.Tag{
+		{
+			Key:   aws.String("Name"),
+			Value: aws.String(name),
+		},
+	}
+
+	for _, t := range tags {
+		key := aws.StringValue(t.Key)
+		if strings.ToLower(key) != "spinup:category" && strings.ToLower(key) != "name" {
+			output = append(output, &iam.Tag{
+				Key:   t.Key,
+				Value: t.Value,
+			})
+		}
+	}
+
+	return output
+}
+
+func (o *Orchestrator) processServiceTagsUpdate(ctx context.Context, active *ServiceOrchestrationUpdateOutput, tags []*Tag) error {
+	log.Debugf("processing tags update with tags list %s", awsutil.Prettify(tags))
+
+	// resources with the spaceid as their name tag (clusters, cloudwatchlogs loggroups, etc)
+	spaceIdNameTags := sharedResourceTags(aws.StringValue(active.Cluster.ClusterName), tags)
+	spaceIdNameArns := []*string{active.Cluster.ClusterArn}
+	spaceIdNameArns = append(spaceIdNameArns, aws.StringSlice(active.CloudwatchLogGroups)...)
+	if err := o.ResourceGroupsTaggingAPI.TagResource(ctx, spaceIdNameArns, spaceIdNameTags); err != nil {
+		return err
+	}
+
+	// get the ecs task execution role arn from the active task definition
+	ecsTaskExecutionRoleArn, err := arn.Parse(aws.StringValue(active.TaskDefinition.ExecutionRoleArn))
+	if err != nil {
+		return err
+	}
+
+	// determine the ecs task execution role name from the arn
+	ecsTaskExecutionRoleName := ecsTaskExecutionRoleArn.Resource[strings.LastIndex(ecsTaskExecutionRoleArn.Resource, "/")+1:]
+
+	// TODO roles don't currently support the resourcegroupstaggingapi
+	// roleTags := sharedResourceTags(ecsTaskExecutionRoleName, tags)
+	// if err := o.ResourceGroupsTaggingAPI.TagResource(ctx, []*string{
+	// 	active.TaskDefinition.ExecutionRoleArn,
+	// }, roleTags); err != nil {
+	// 	return err
+	// }
+
+	roleTags := roleTags(ecsTaskExecutionRoleName, tags)
+	if err := o.IAM.TagRole(ctx, ecsTaskExecutionRoleName, roleTags); err != nil {
+		return err
+	}
+
+	commonTags := specificResourceTags(tags)
+
+	commonArns := []*string{
+		active.Service.ServiceArn,
+		active.TaskDefinition.TaskDefinitionArn,
+	}
+
+	// collect secretsmanager ARNs
+	for _, containerDef := range active.TaskDefinition.ContainerDefinitions {
+		repositoryCredentials := containerDef.RepositoryCredentials
+		if repositoryCredentials != nil && repositoryCredentials.CredentialsParameter != nil {
+			commonArns = append(commonArns, repositoryCredentials.CredentialsParameter)
+		}
+	}
+
+	if err := o.ResourceGroupsTaggingAPI.TagResource(ctx, commonArns, commonTags); err != nil {
+		return err
+	}
+
+	// set the active tags for output
+	active.Tags = tags
+
+	return err
+}
+
+func (o *Orchestrator) processTaskDefTagsUpdate(ctx context.Context, active *TaskDefUpdateOrchestrationOutput, tags []*Tag) error {
+	log.Debugf("processing tags update with tags list %s", awsutil.Prettify(tags))
+
+	// resources with the spaceid as their name tag (clusters, cloudwatchlogs loggroups, etc)
+	spaceIdNameTags := sharedResourceTags(aws.StringValue(active.Cluster.ClusterName), tags)
+	spaceIdNameArns := []*string{active.Cluster.ClusterArn}
+	spaceIdNameArns = append(spaceIdNameArns, aws.StringSlice(active.CloudwatchLogGroups)...)
+	if err := o.ResourceGroupsTaggingAPI.TagResource(ctx, spaceIdNameArns, spaceIdNameTags); err != nil {
+		return err
+	}
+
+	// get the ecs task execution role arn from the active task definition
+	ecsTaskExecutionRoleArn, err := arn.Parse(aws.StringValue(active.TaskDefinition.ExecutionRoleArn))
+	if err != nil {
+		return err
+	}
+
+	// determine the ecs task execution role name from the arn
+	ecsTaskExecutionRoleName := ecsTaskExecutionRoleArn.Resource[strings.LastIndex(ecsTaskExecutionRoleArn.Resource, "/")+1:]
+
+	// TODO roles don't currently support the resourcegroupstaggingapi
+	// roleTags := sharedResourceTags(ecsTaskExecutionRoleName, tags)
+	// if err := o.ResourceGroupsTaggingAPI.TagResource(ctx, []*string{
+	// 	active.TaskDefinition.ExecutionRoleArn,
+	// }, roleTags); err != nil {
+	// 	return err
+	// }
+
+	roleTags := roleTags(ecsTaskExecutionRoleName, tags)
+	if err := o.IAM.TagRole(ctx, ecsTaskExecutionRoleName, roleTags); err != nil {
+		return err
+	}
+
+	commonTags := specificResourceTags(tags)
+
+	commonArns := []*string{
+		active.TaskDefinition.TaskDefinitionArn,
+	}
+
+	// collect secretsmanager ARNs
+	for _, containerDef := range active.TaskDefinition.ContainerDefinitions {
+		repositoryCredentials := containerDef.RepositoryCredentials
+		if repositoryCredentials != nil && repositoryCredentials.CredentialsParameter != nil {
+			commonArns = append(commonArns, repositoryCredentials.CredentialsParameter)
+		}
+	}
+
+	if err := o.ResourceGroupsTaggingAPI.TagResource(ctx, commonArns, commonTags); err != nil {
+		return err
+	}
+
+	// set the active tags for output
+	active.Tags = tags
+
+	return err
 }

--- a/orchestration/tags_test.go
+++ b/orchestration/tags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
@@ -81,4 +82,240 @@ func TestSecretsmanagerTags(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_sharedResourceTags(t *testing.T) {
+	type args struct {
+		name string
+		tags []*Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]*string
+	}{
+		{
+			name: "skip category",
+			args: args{
+				name: "get-a-clu",
+				tags: []*Tag{
+					{
+						Key:   aws.String("spinup:category"),
+						Value: aws.String("thingy"),
+					},
+				},
+			},
+			want: map[string]*string{"Name": aws.String("get-a-clu")},
+		},
+		{
+			name: "override name",
+			args: args{
+				name: "get-a-clu",
+				tags: []*Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String("thingy1"),
+					},
+					{
+						Key:   aws.String("name"),
+						Value: aws.String("thingy2"),
+					},
+				},
+			},
+			want: map[string]*string{"Name": aws.String("get-a-clu")},
+		},
+		{
+			name: "tag list",
+			args: args{
+				name: "get-a-clu",
+				tags: []*Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String("thingy1"),
+					},
+					{
+						Key:   aws.String("some"),
+						Value: aws.String("thingy2"),
+					},
+					{
+						Key:   aws.String("other"),
+						Value: aws.String("thingy3"),
+					},
+				},
+			},
+			want: map[string]*string{
+				"Name":  aws.String("get-a-clu"),
+				"some":  aws.String("thingy2"),
+				"other": aws.String("thingy3"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sharedResourceTags(tt.args.name, tt.args.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sharedResourceTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_specificResourceTags(t *testing.T) {
+	type args struct {
+		tags []*Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]*string
+	}{
+		{
+			name: "category",
+			args: args{
+				tags: []*Tag{
+					{
+						Key:   aws.String("spinup:category"),
+						Value: aws.String("thingy"),
+					},
+				},
+			},
+			want: map[string]*string{"spinup:category": aws.String("thingy")},
+		},
+		{
+			name: "name",
+			args: args{
+				tags: []*Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String("thingy1"),
+					},
+				},
+			},
+			want: map[string]*string{"Name": aws.String("thingy1")},
+		},
+		{
+			name: "tag list",
+			args: args{
+				tags: []*Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String("thingy1"),
+					},
+					{
+						Key:   aws.String("some"),
+						Value: aws.String("thingy2"),
+					},
+					{
+						Key:   aws.String("other"),
+						Value: aws.String("thingy3"),
+					},
+				},
+			},
+			want: map[string]*string{
+				"Name":  aws.String("thingy1"),
+				"some":  aws.String("thingy2"),
+				"other": aws.String("thingy3"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := specificResourceTags(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("specificResourceTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_roleTags(t *testing.T) {
+	type args struct {
+		name string
+		tags []*Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*iam.Tag
+	}{
+		{
+			name: "skip category",
+			args: args{
+				name: "bestRole",
+				tags: []*Tag{
+					{
+						Key:   aws.String("spinup:category"),
+						Value: aws.String("thingy"),
+					},
+				},
+			},
+			want: []*iam.Tag{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("bestRole"),
+				},
+			},
+		},
+		{
+			name: "override name",
+			args: args{
+				name: "bestRole",
+				tags: []*Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String("thingy1"),
+					},
+				},
+			},
+			want: []*iam.Tag{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("bestRole"),
+				},
+			},
+		},
+		{
+			name: "tag list",
+			args: args{
+				name: "bestRole",
+				tags: []*Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String("thingy1"),
+					},
+					{
+						Key:   aws.String("name"),
+						Value: aws.String("littlethingy1"),
+					},
+					{
+						Key:   aws.String("some"),
+						Value: aws.String("thingy2"),
+					},
+					{
+						Key:   aws.String("other"),
+						Value: aws.String("thingy3"),
+					},
+				},
+			},
+			want: []*iam.Tag{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("bestRole"),
+				},
+				{
+					Key:   aws.String("some"),
+					Value: aws.String("thingy2"),
+				},
+				{
+					Key:   aws.String("other"),
+					Value: aws.String("thingy3"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := roleTags(tt.args.name, tt.args.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("roleTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Tagging cleanup is a WIP, but this is a step in the direction of completely shared tagging logic for services and tasks.  It also adds tags to one of the resources that was missing.

* Use common tag generation logic for services and tasks
* Add tags to cloudwatchlogs log-groups