### PR TITLE
Standardize on spinup:type and spinup:flavor tags

### DIFF
--- a/orchestration/cluster.go
+++ b/orchestration/cluster.go
@@ -116,6 +116,16 @@ func (o *Orchestrator) deleteCluster(ctx context.Context, arn *string) (bool, er
 		return false, nil
 	}
 
+	tasks, err := o.ListTaskDefs(ctx, aws.StringValue(cluster.ClusterName))
+	if err != nil {
+		return false, err
+	}
+
+	if l := len(tasks); l > 0 {
+		log.Debugf("cluster has %d taskdefs defined, not deleting", l)
+		return false, nil
+	}
+
 	cluCtx, cluCancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cluCancel()
 

--- a/orchestration/orchestration_service.go
+++ b/orchestration/orchestration_service.go
@@ -96,7 +96,7 @@ func (o *Orchestrator) CreateService(ctx context.Context, input *ServiceOrchestr
 
 	spaceid := aws.StringValue(input.Cluster.ClusterName)
 
-	ct, err := cleanTags(o.Org, spaceid, input.Tags)
+	ct, err := cleanTags(o.Org, spaceid, "container", "service", input.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (o *Orchestrator) UpdateService(ctx context.Context, cluster, service strin
 
 	// if the input tags are passed, clean them and use them, otherwise set to the active service tags
 	if input.Tags != nil {
-		ct, err := cleanTags(o.Org, cluster, input.Tags)
+		ct, err := cleanTags(o.Org, cluster, "container", "service", input.Tags)
 		if err != nil {
 			return nil, err
 		}

--- a/orchestration/taskdefinition.go
+++ b/orchestration/taskdefinition.go
@@ -32,12 +32,6 @@ func (o *Orchestrator) processTaskDefinitionCreate(ctx context.Context, input *S
 
 	log.Debugf("processing task definition create for a service %+v", input.TaskDefinition)
 
-	// task definition gets a special tag denoting it as defined for a service
-	input.TaskDefinition.Tags = append(ecsTags(input.Tags), &ecs.Tag{
-		Key:   aws.String("spinup:category"),
-		Value: aws.String("container-service"),
-	})
-
 	// path is org/clustername
 	path := fmt.Sprintf("%s/%s", o.Org, aws.StringValue(input.Cluster.ClusterName))
 
@@ -97,12 +91,6 @@ func (o *Orchestrator) processTaskDefTaskDefinitionCreate(ctx context.Context, i
 	}
 
 	log.Debugf("processing task definition create for a task %+v", input.TaskDefinition)
-
-	// task definition gets a special tag denoting it as defined as a task definition
-	input.TaskDefinition.Tags = append(ecsTags(input.Tags), &ecs.Tag{
-		Key:   aws.String("spinup:category"),
-		Value: aws.String("container-taskdef"),
-	})
 
 	// path is org/clustername
 	path := fmt.Sprintf("%s/%s", o.Org, aws.StringValue(input.Cluster.ClusterName))


### PR DESCRIPTION
* add `spinup:type` and `spinup:flavor` tags for tasksdefs and services
* check if there are task definitions defined before recursively deleting a service
* delete cluster when recursively deleting task defs