### PR TITLE
Accept OCI Image Format For Verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ k8s/k8s-config.yaml
 vendor
 .vscode
 
+.idea
+tmp

--- a/registry/verifier.go
+++ b/registry/verifier.go
@@ -102,7 +102,7 @@ func (v *Verifier) Verify(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "unable to create new request for "+url)
 	}
-	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json")
 
 	if creds := v.Credentials; creds != nil {
 		log.Debugf("setting basic auth for initial request (username: %s)", creds.Username)


### PR DESCRIPTION
- Currently, if a user is trying to verify an OCI image when going through the process of creating a container service, their image will not verify
- The outgoing request to verify only expects to accept docker formatted images, so it needed to be updated to also accept oci format

You can use `ghcr.io/kljensen/hello-world-http:0.4.0` as an image that was not verifying but will not verify correclty.